### PR TITLE
Add 30 second delay between running API gateway test suites

### DIFF
--- a/tools/travis/install_openwhisk.sh
+++ b/tools/travis/install_openwhisk.sh
@@ -35,4 +35,9 @@ cp $TRAVIS_BUILD_DIR/wsk $WHISKDIR/bin
 # Run the test cases under openwhisk to ensure the quality of the binary.
 cd $WHISKDIR
 ./gradlew :tests:test -Dtest.single=Wsk*Tests*
-./gradlew :tests:test -Dtest.single=ApiGw*Tests*
+sleep 30
+./gradlew tests:test -Dtest.single=*ApiGwRoutemgmtActionTests*
+sleep 30
+./gradlew tests:test -Dtest.single=*ApiGwTests*
+sleep 30
+./gradlew tests:test -Dtest.single=*ApiGwEndToEndTests*


### PR DESCRIPTION
Since openwhisk throttles any given user from issuing too many
requests in a rolling 1 minute period, we need to add the time deply
between running any two api gateway test suites.