### PR TITLE
WIP Changes required to add service bindings to the Bluemix plugin

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -31,6 +31,14 @@ import (
 var client *whisk.Client
 const DefaultOpenWhiskApiPath string = "/api"
 
+func GetClient() *whisk.Client {
+    return client
+}
+
+func SetupClientConfig(cmd *cobra.Command, args []string) (error){
+    return setupClientConfig(cmd, args)
+}
+
 func setupClientConfig(cmd *cobra.Command, args []string) (error){
     baseURL, err := GetURLBase(Properties.APIHost, DefaultOpenWhiskApiPath)
 

--- a/commands/qualified_name.go
+++ b/commands/qualified_name.go
@@ -28,7 +28,7 @@ type QualifiedName struct {
     namespace   string  // namespace. does not include leading '/'.  may be "" (i.e. default namespace)
     packageName string  // package.  may be "".  does not include leading/trailing '/'
     entity      string  // entity.  should not be ""
-    entityName  string  // pkg+entity
+    EntityName  string  // pkg+entity
 }
 
 ///////////////////////////
@@ -61,7 +61,7 @@ func (qualifiedName *QualifiedName) GetPackageName() string {
 //  GetEntityName() returns the entity name ([package/]entity) of qualifiedName
 //      without a leading '/'
 func (qualifiedName *QualifiedName) GetEntityName() string {
-    return qualifiedName.entityName
+    return qualifiedName.EntityName
 }
 
 //  GetEntity() returns the name of entity in qualifiedName without a leading '/'
@@ -110,7 +110,7 @@ func NewQualifiedName(name string) (*QualifiedName, error) {
             }
         }
 
-        qualifiedName.entityName = strings.Join(parts[2:], "/")
+        qualifiedName.EntityName = strings.Join(parts[2:], "/")
         if len(parts) == 4 {
             qualifiedName.packageName = parts[2]
         }
@@ -124,7 +124,7 @@ func NewQualifiedName(name string) (*QualifiedName, error) {
         if len(parts) == 2 {
             qualifiedName.packageName = parts[0]
         }
-        qualifiedName.entityName = name
+        qualifiedName.EntityName = name
         qualifiedName.namespace = getNamespaceFromProp()
     }
 

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -1522,4 +1522,8 @@
   {
     "id": "sorts a list alphabetically by order of [BASE_PATH | API_NAME], API_PATH, then API_VERB; only applicable within the limit/skip returned entity block",
     "translation": "sorts a list alphabetically by order of [BASE_PATH | API_NAME], API_PATH, then API_VERB; only applicable within the limit/skip returned entity block"
+  },
+  {
+    "id": "A valid qualified name must be specified.",
+    "translation": "A valid qualified name must be specified."
   }]


### PR DESCRIPTION
Essentially just added some publicly exported functions, which called the private versions.  This helped to have a smaller ripple effect across the code base as some of the functions that we needed to export would force changes across the entire API. 

This can still be done, but at least for the time being I'd prefer to do it this way and then fix this up (i.e. removing the duplicate methods that only have a difference in their case of the first character of the name and just making the required methods publicly exported) .   This way we can meet the deadline with less risk as there wouldn't be as many changes across the entire cli code base.