### PR TITLE
Add s390x architecture to build.

### DIFF
--- a/tools/travis/build_tag_releases.sh
+++ b/tools/travis/build_tag_releases.sh
@@ -1,29 +1,37 @@
 #!/usr/bin/env bash
 
-declare -a os_list=("linux" "windows" "darwin")
-declare -a arc_list=("amd64" "386")
+#  Currently supported combinations of OS and Architecture
+declare -a builds=(
+    "linux amd64"
+    "linux 386"
+    "linux s390x"
+    "darwin amd64"
+    "darwin 386"
+    "windows amd64"
+    "windows 386"
+)
+
 build_file_name=${1:-"wsk"}
 zip_file_name=${2:-"OpenWhisk_CLI"}
 
-for os in "${os_list[@]}"
+for build in "${builds[@]}"
 do
-    for arc in "${arc_list[@]}"
-    do
-        wsk=$build_file_name
-        os_name=$os
-        if [ "$os" == "windows" ]; then
-            wsk="$wsk.exe"
-        fi
-        if [ "$os" == "darwin" ]; then
-            os_name="mac"
-        fi
-        cd $TRAVIS_BUILD_DIR
-        GOOS=$os GOARCH=$arc go build -ldflags "-X main.CLI_BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%S%:z'`" -o build/$os/$arc/$wsk
-        cd build/$os/$arc
-        if [[ "$os" == "linux" ]]; then
-            tar -czvf "$TRAVIS_BUILD_DIR/$zip_file_name-$TRAVIS_TAG-$os_name-$arc.tgz" $wsk
-        else
-            zip -r "$TRAVIS_BUILD_DIR/$zip_file_name-$TRAVIS_TAG-$os_name-$arc.zip" $wsk
-        fi
-    done
+    # A little bash foo to tokenize the build string
+    IFS=' ' read os arc <<< "${build}"
+    wsk=$build_file_name
+    os_name=$os
+    if [ "$os" == "windows" ]; then
+        wsk="$wsk.exe"
+    fi
+    if [ "$os" == "darwin" ]; then
+        os_name="mac"
+    fi
+    cd $TRAVIS_BUILD_DIR || exit
+    GOOS=$os GOARCH=$arc go build -ldflags "-X main.CLI_BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%S%:z'`" -o build/$os/$arc/$wsk
+    cd build/$os/$arc || exit
+    if [[ "$os" == "linux" ]]; then
+        tar -czvf "$TRAVIS_BUILD_DIR/$zip_file_name-$TRAVIS_TAG-$os_name-$arc.tgz" $wsk
+    else
+        zip -r "$TRAVIS_BUILD_DIR/$zip_file_name-$TRAVIS_TAG-$os_name-$arc.zip" $wsk
+    fi
 done


### PR DESCRIPTION
Re-submitting [PR #171](https://github.com/apache/incubator-openwhisk-cli/pull/171) on a separate branch, because of merge difficulties.

As part of preparing OpenWhisk builds for multi-architecture deployment, it's necessary to cross-compile the 'wsk' binary for target architectures. This adds a cross-compile for s390x architecture. I've tested that the cross-compile works appropriately from a command-line build; I'm working through the remote deployment approach here.