### PR TITLE
Handle namespace API listing on the client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ javascript/
 wsk
 scripts
 Godeps/_workspace
+.idea/
+*.iml
+.gradle

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -65,7 +65,7 @@
 		},
         {
             "ImportPath": "github.com/apache/incubator-openwhisk-client-go/whisk",
-            "Rev": "a67e8509a92beb6c68f0c9da43562af1f5d2b13c"
+            "Rev": "ba3bbee442357a239667ef6de378d5b7d33e0ceb"
         }
 	]
 }

--- a/commands/namespace.go
+++ b/commands/namespace.go
@@ -70,9 +70,11 @@ var namespaceGetCmd = &cobra.Command{
         var err error
         var namespace string = getClientNamespace()
 
-        if whiskErr := CheckArgs(args,0,0,"Namespace get",
+        if (!(len(args) == 1 && args[0] == "/_")) {
+            if whiskErr := CheckArgs(args, 0, 0, "Namespace get",
                 wski18n.T("No arguments are required.")); whiskErr != nil {
-            return whiskErr
+                return whiskErr
+            }
         }
 
         actions, _, err := Client.Actions.List("", &whisk.ActionListOptions{ Skip: 0, Limit: 0 })

--- a/commands/shared.go
+++ b/commands/shared.go
@@ -33,3 +33,12 @@ func entityNameError(entityName string) (error) {
 
     return whisk.MakeWskError(errors.New(errMsg), whisk.EXIT_CODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
 }
+
+func entityListError(err error, namespace string, kind string) error {
+    whisk.Debug(whisk.DbgError, "Client.%s.List(%s) error: %s\n", kind, namespace, err)
+    errStr := wski18n.T("Unable to obtain the list of entities for namespace '{{.namespace}}': {{.err}}",
+        map[string]interface{}{"namespace": namespace, "err": err})
+    return whisk.MakeWskErrorFromWskError(errors.New(errStr), err,
+        whisk.EXIT_CODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+}
+

--- a/tests/src/integration/integration_test.go
+++ b/tests/src/integration/integration_test.go
@@ -139,8 +139,8 @@ func initInvalidArgs() {
             Err: tooManyArgsMsg + invalidArg + ". " + noArgsReqMsg,
         },
         common.InvalidArg {
-            Cmd: []string{"namespace", "get", "namespace", invalidArg},
-            Err: tooManyArgsMsg + invalidArg + ". " + optNamespaceMsg,
+            Cmd: []string{"namespace", "get", invalidArg},
+            Err: tooManyArgsMsg + invalidArg + ". " + noArgsReqMsg,
         },
         common.InvalidArg {
             Cmd: []string{"package", "create"},

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -776,16 +776,14 @@ class WskBasicTests extends TestHelpers with WskTestHelpers {
   }
 
   it should "list entities in default namespace" in {
-    // use a fresh wsk props instance that is guaranteed to use
-    // the default namespace
+    // use a fresh wsk props instance that is guaranteed to use the default namespace
     wsk.namespace.get(expectedExitCode = SUCCESS_EXIT)(WskProps()).stdout should include("default")
   }
 
-  it should "not list entities with an invalid namespace" in {
+  it should "not accept a namespace on 'wsk list' or 'wsk namespace get'" in {
     val namespace = "fakeNamespace"
-    val stderr = wsk.namespace.get(Some(s"/${namespace}"), expectedExitCode = FORBIDDEN).stderr
-
-    stderr should include(s"Unable to obtain the list of entities for namespace '${namespace}'")
+    val stderr = wsk.namespace.get(Some(s"/${namespace}"), expectedExitCode = MISUSE_EXIT).stderr
+    stderr should include(s"No arguments are required.'")
   }
 
   behavior of "Wsk Activation CLI"

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -780,12 +780,6 @@ class WskBasicTests extends TestHelpers with WskTestHelpers {
     wsk.namespace.get(expectedExitCode = SUCCESS_EXIT)(WskProps()).stdout should include("default")
   }
 
-  it should "not accept a namespace on 'wsk list' or 'wsk namespace get'" in {
-    val namespace = "fakeNamespace"
-    val stderr = wsk.namespace.get(Some(s"/${namespace}"), expectedExitCode = MISUSE_EXIT).stderr
-    stderr should include(s"No arguments are required.'")
-  }
-
   behavior of "Wsk Activation CLI"
 
   it should "create a trigger, and fire a trigger to get its individual fields from an activation" in withAssetCleaner(

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -1632,7 +1632,7 @@ class WskBasicUsageTests extends TestHelpers with WskTestHelpers {
       (Seq("activation", "result", "activationID", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
       (Seq("activation", "poll", "activationID", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
       (Seq("namespace", "list", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${noArgsReqMsg}"),
-      (Seq("namespace", "get", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("namespace", "get", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${noArgsReqMsg}"),
       (Seq("package", "create"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
       (Seq("package", "create", "packageName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
       (Seq("package", "create", "packageName", "--shared", invalidArg), invalidShared),

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -72,8 +72,8 @@
     "translation": "Unable to obtain the list of available namespaces: {{.err}}"
   },
   {
-    "id": "get triggers, actions, and rules in the registry for a namespace",
-    "translation": "get triggers, actions, and rules in the registry for a namespace"
+    "id": "get triggers, actions, and rules in the registry for namespace",
+    "translation": "get triggers, actions, and rules in the registry for namespace"
   },
   {
     "id": "'{{.name}}' is not a valid qualified name: {{.err}}",


### PR DESCRIPTION
Replaces call to GET /namespace/_ with calls to GET /namespace/_/[actions, triggers, rules, packages]

For https://github.com/apache/incubator-openwhisk/issues/3153
Fixes #186 