### PR TITLE
Add ppc64le to arch to build cli

### DIFF
--- a/tools/travis/build_tag_releases.sh
+++ b/tools/travis/build_tag_releases.sh
@@ -5,6 +5,7 @@ declare -a builds=(
     "linux amd64"
     "linux 386"
     "linux s390x"
+    "linux ppc64le"
     "darwin amd64"
     "darwin 386"
     "windows amd64"


### PR DESCRIPTION
This patch adds support for ppc64le architecture for cross compile
builds for the wsk CLI, following the same suite of changes done
for s390x.