### PR TITLE
Travis cd to right directory to ls deployed files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ after_success:
     fi
 
 before_deploy:
-  - export RELEASE_PKG_FILE=$(cd './release' && ls "${zip_file_name}-*.tgz" "${zip_file_name}-*.zip")
+  - export RELEASE_PKG_FILE=$(cd "$TRAVIS_BUILD_DIR/release" && ls "${zip_file_name}-*.tgz" "${zip_file_name}-*.zip")
   - echo "Deploying $RELEASE_PKG_FILE to GitHub releases."
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     - secure: "Br0fD9CAKm8gqyEuwmltNJd4dGJCxPpj6feugHlO+CFFwfE/+kJKkpTlsDuRfrUzUDlWiETNPf0XGSjvPFqZExnLCE9XQh2+XF6u+S3YBWfM+rbbyRVAK6BlTwmt0u3jRJ2JP7spedTGZA+qfIWI+UkwoOexo7NcqtMPLahiZzheaaad8y3J+crHQCrB/kPrhLqKVMEOkIbveFdfV2QLfCOWgqP8e1LGZhPZ2N4QcNo0iB5uI4ZyYszTZDniXFKxz7kBs4tl4ZQDqRHqL02qKPsjbvjrZp83ql+PbC2dpgXi9YpaDuBEqKKX1rTQP5ppcwbobot5U3ItHWzpXbLCdsWxvbde/0enjMmOF1wwl71hPYIf7PkQmNAWXRtL2Z1TguO/dKCeXBLDER4YDQ79GYpikAMqnrRLou4rsyZrNUzg8aHbELzAHppDSpqEJN8ymGgWgmWBT8yPaWVwN5CjPFOxLPrVEObcwcNSGOcOvtmUGCnXKSZminNZUjz5QfWqpA+LYCUIbeOI2X2D+iQWklWONaU2A+PcNLaaegwwj4K+9ZlU08Ed8Ud5ZGhjN9s72OtoFPdSHAyBgf/qxIdnTzmmE+SQ90mDtG3VqjHy28Ix7cIGqaIEC8shFb0kKHqQ7AVkLPm0bsh2fbbYu/5YVpXHfxlKWfOLBV14bHUq3v0="
     - build_file_name=wsk
+    # WARNING: if zip_file_name includes spaces or leading hyphen(s), it will create cosmetic breakage in 'before_deploy'
     - zip_file_name=OpenWhisk_CLI
 
 
@@ -53,7 +54,7 @@ after_success:
     fi
 
 before_deploy:
-  - export RELEASE_PKG_FILE=$(cd "$TRAVIS_BUILD_DIR/release" && ls "${zip_file_name}-*.tgz" "${zip_file_name}-*.zip")
+  - export RELEASE_PKG_FILE="$(cd "$TRAVIS_BUILD_DIR/release" && ls ${zip_file_name}-*.tgz ${zip_file_name}-*.zip)"
   - echo "Deploying $RELEASE_PKG_FILE to GitHub releases."
 
 deploy:


### PR DESCRIPTION
Small change to the `before_deploy` stanza in `.travis.yml` to (hopefully) have it source its list of files to be deployed from within the `$TRAVIS_BUILD_DIR/release` directory instead of wherever it's ending up now.