### PR TITLE
Prevent execution of 'incubator-openwhisk' tests when './gradlew test' is run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ Godeps/_workspace
 # Gradle build working directories
 /.gradle/
 /.gogradle/
-/build/
+build
 /release/
 /vendor/

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -3,6 +3,10 @@ apply plugin: 'eclipse'
 compileTestScala.options.encoding = 'UTF-8'
 
 evaluationDependsOn(':clitests')
+evaluationDependsOn(':common:scala')
+
+project(':clitests').test.onlyIf = {false}
+compileTestScala.dependsOn(':clitests:compileTestScala')
 
 repositories {
     mavenCentral()
@@ -27,6 +31,10 @@ dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':clitests')
     compile project(':clitests').sourceSets.test.output
+
+    compile project(':common:scala')
+    compile project(':core:controller')
+    compile project(':core:invoker')
 }
 
 tasks.withType(ScalaCompile) {

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -36,7 +36,6 @@ import common.WhiskProperties
 import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
-import common.SimpleExec
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -44,6 +43,7 @@ import spray.json.DefaultJsonProtocol._
 import system.rest.RestUtil
 
 import whisk.common.PrintStreamLogging
+import whisk.common.SimpleExec
 import whisk.common.TransactionId
 import whisk.core.entity.Subject
 

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -36,6 +36,7 @@ import common.WhiskProperties
 import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
+import common.SimpleExec
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -43,7 +44,6 @@ import spray.json.DefaultJsonProtocol._
 import system.rest.RestUtil
 
 import whisk.common.PrintStreamLogging
-import whisk.common.SimpleExec
 import whisk.common.TransactionId
 import whisk.core.entity.Subject
 


### PR DESCRIPTION
Per issue #211, this PR removes execution of the 'incubator-openwhisk' test tests when './gradlew test' is executed, while retaining the ability to execute all scala tests in the 'incubator-openwhisk-cli' repository.  This is an incremental improvement to the testing framework; more refinements are likely to follow but this can (and should) be committed once passing Travis and reviewed.