### PR TITLE
Make './gradlew build' depend on 'compile' task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,8 @@ task compile(type: Copy, dependsOn: goBuild) {
     from("./build/${rootProject.localPlatform.goOs}-${rootProject.localPlatform.goArch}")
 }
 
+task build(type: DefaultTask, dependsOn: compile)
+
 /*
     For each platform, create an individual archive in a platform appropriate
     format (tarball for Linux, zipfile for Mac & Windows).


### PR DESCRIPTION
Per issue #211, added a 'build' task to the script that would depend on compile.  It seems that other builds are or are not done as appropriate.  Tests from 'incubator-openwhisk-cli' are still run, but that is typical for gradle builds -- I'd advise against changing that behavior.