### PR TITLE
Travis local cli

### DIFF
--- a/tools/travis/test_openwhisk.sh
+++ b/tools/travis/test_openwhisk.sh
@@ -62,14 +62,13 @@ cd $OPENWHISK_HOME
 #  Fire up the cluster
 cd $OPENWHISK_HOME/ansible
 ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=testing"
-
 $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD prereq.yml
 $ANSIBLE_CMD couchdb.yml
 $ANSIBLE_CMD initdb.yml
 $ANSIBLE_CMD apigateway.yml
 $ANSIBLE_CMD wipe.yml
-OPENWHISK_CLI_MODE=local $ANSIBLE_CMD openwhisk.yml -e openwhisk_cli_home=$TRAVIS_BUILD_DIR
+$ANSIBLE_CMD openwhisk.yml -e cli_installation_mode=local -e openwhisk_cli_home=$TRAVIS_BUILD_DIR
 
 #  Run the test cases under openwhisk to ensure the quality of the runnint API.
 cd $TRAVIS_BUILD_DIR

--- a/tools/travis/test_openwhisk.sh
+++ b/tools/travis/test_openwhisk.sh
@@ -62,17 +62,14 @@ cd $OPENWHISK_HOME
 #  Fire up the cluster
 cd $OPENWHISK_HOME/ansible
 ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=testing"
+
 $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD prereq.yml
 $ANSIBLE_CMD couchdb.yml
 $ANSIBLE_CMD initdb.yml
 $ANSIBLE_CMD apigateway.yml
 $ANSIBLE_CMD wipe.yml
-$ANSIBLE_CMD openwhisk.yml -e openwhisk_cli_home=$TRAVIS_BUILD_DIR
-
-# Copy the binary generated into the OPENWHISK_HOME/bin, so that the test cases will run based on it.
-mkdir -p $OPENWHISK_HOME/bin
-cp -f $TRAVIS_BUILD_DIR/build/wsk $OPENWHISK_HOME/bin
+OPENWHISK_CLI_MODE=local $ANSIBLE_CMD openwhisk.yml -e openwhisk_cli_home=$TRAVIS_BUILD_DIR
 
 #  Run the test cases under openwhisk to ensure the quality of the runnint API.
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
See https://github.com/apache/incubator-openwhisk/issues/3329

These changes to the travis build script should cause it to exercise the CLI copy logic in the ansible scripts executing tests against OpenWhisk.