### PR TITLE
Update User Agent Test

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -117,7 +117,7 @@ class WskBasicUsageTests extends TestHelpers with WskTestHelpers {
   }
 
   it should "include CLI user agent headers with outbound requests" in {
-    val stdout = wsk.cli(Seq("list", "--auth", wskprops.authKey) ++ wskprops.overrides, verbose = true).stdout
+    val stdout = wsk.cli(Seq("action", "list", "--auth", wskprops.authKey) ++ wskprops.overrides, verbose = true).stdout
     stdout should include regex (usrAgentHeaderRegEx)
   }
 


### PR DESCRIPTION
The current test uses `wsk list` to examine the user agent value. This is problematic as `wsk list` calls `wsk rule list`, and `wsk rule list` attempts to get the status of every rule that is listed individually. If a rule that was listed is deleted by the time the CLI gets that rule's status, the test will fail.

Perhaps we need to suppress the error from `wsk rule list`.

Related to https://github.com/apache/incubator-openwhisk-cli/issues/232.