### PR TITLE
Addition HTTP Headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
         build(['name':'golang.org/x/sys/unix', 'version':'7f918dd405547ecb864d14a8ecbbfe205b5f930f', 'transitive':false])
         build(['name':'gopkg.in/yaml.v2', 'version':'cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b', 'transitive':false])
         build(['name':'github.com/ghodss/yaml', 'version':'0ca9ea5df5451ffdf184b4428c902747c2c11cd7', 'transitive':false])
-        build(['name':'github.com/apache/incubator-openwhisk-client-go/whisk','version':'025300c38d0b790d161d3776d84e1da340e2b202','transitive':false])
+        build(['name':'github.com/apache/incubator-openwhisk-client-go/whisk','version':'012fd0fb022fd542fdd7606567d0c9b38ca56bd8','transitive':false])
         // END - Imported from Godeps
         test name:'github.com/stretchr/testify', version:'b91bfb9ebec76498946beb6af7c0230c7cc7ba6c', transitive:false //, tag: 'v1.2.0'
         test name:'github.com/spf13/viper', version:'aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5', transitive:false

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -33,6 +33,7 @@ var Client *whisk.Client
 const DefaultOpenWhiskApiPath string = "/api"
 
 var UserAgent string = "OpenWhisk-CLI"
+var AdditionalHeaders map[string]string
 
 func SetupClientConfig(cmd *cobra.Command, args []string) error {
 	baseURL, err := whisk.GetURLBase(Properties.APIHost, DefaultOpenWhiskApiPath)
@@ -55,15 +56,16 @@ func SetupClientConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	clientConfig := &whisk.Config{
-		Cert:      Properties.Cert,
-		Key:       Properties.Key,
-		AuthToken: Properties.Auth,
-		Namespace: Properties.Namespace,
-		BaseURL:   baseURL,
-		Version:   Properties.APIVersion,
-		Insecure:  Flags.Global.Insecure,
-		Host:      Properties.APIHost,
-		UserAgent: UserAgent + "/1.0 (" + Properties.CLIVersion + ")",
+		Cert:              Properties.Cert,
+		Key:               Properties.Key,
+		AuthToken:         Properties.Auth,
+		Namespace:         Properties.Namespace,
+		BaseURL:           baseURL,
+		Version:           Properties.APIVersion,
+		Insecure:          Flags.Global.Insecure,
+		Host:              Properties.APIHost,
+		UserAgent:         UserAgent + "/1.0 (" + Properties.CLIVersion + ")",
+		AdditionalHeaders: AdditionalHeaders,
 	}
 
 	if len(clientConfig.Host) == 0 {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -33,7 +33,7 @@ var Client *whisk.Client
 const DefaultOpenWhiskApiPath string = "/api"
 
 var UserAgent string = "OpenWhisk-CLI"
-var AdditionalHeaders map[string]string
+var AdditionalHeaders http.Header
 
 func SetupClientConfig(cmd *cobra.Command, args []string) error {
 	baseURL, err := whisk.GetURLBase(Properties.APIHost, DefaultOpenWhiskApiPath)


### PR DESCRIPTION
Allows for additional HTTP headers to be configured for client-go.

Depends on https://github.com/apache/incubator-openwhisk-client-go/pull/67.