### PR TITLE
Use HTTP instead of HTTPS for controller

### DIFF
--- a/tools/travis/test_openwhisk.sh
+++ b/tools/travis/test_openwhisk.sh
@@ -68,7 +68,7 @@ $ANSIBLE_CMD couchdb.yml
 $ANSIBLE_CMD initdb.yml
 $ANSIBLE_CMD apigateway.yml
 $ANSIBLE_CMD wipe.yml
-$ANSIBLE_CMD openwhisk.yml -e cli_installation_mode=local -e openwhisk_cli_home=$TRAVIS_BUILD_DIR
+$ANSIBLE_CMD openwhisk.yml -e cli_installation_mode=local -e openwhisk_cli_home=$TRAVIS_BUILD_DIR -e controllerProtocolForSetup=http
 
 #  Run the test cases under openwhisk to ensure the quality of the runnint API.
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Fixes Travis test failure.

Closes https://github.com/apache/incubator-openwhisk-cli/issues/243