### PR TITLE
Fix test to not compare namespace to subject

### DIFF
--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -947,7 +947,7 @@ class WskBasicTests extends TestHelpers with WskTestHelpers {
       getJSONFromResponse(result.stdout, true).fields("name").convertTo[String] shouldBe triggerName
       getJSONFromResponse(result.stdout, true).fields("version").convertTo[String] shouldBe "0.0.1"
       getJSONFromResponse(result.stdout, true).fields("publish") shouldBe false.toJson
-      getJSONFromResponse(result.stdout, true).fields("subject").convertTo[String] shouldBe ns
+      getJSONFromResponse(result.stdout, true).fields("subject").convertTo[String].length should not be (0)
       getJSONFromResponse(result.stdout, true).fields("activationId").convertTo[String] shouldBe activation.activationId
       getJSONFromResponse(result.stdout, true).fields("start") should not be JsObject()
       getJSONFromResponse(result.stdout, true).fields("end") shouldBe 0.toJson


### PR DESCRIPTION
`create a trigger, and fire a trigger to get its individual fields from an activation` directly compares a namespace to a subject which will result in a failure if the test namespace does not match the subject.