### PR TITLE
Add the support to specify the version of the binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   - cd $TRAVIS_BUILD_DIR/../incubator-openwhisk
   - ./gradlew install
   - cd $TRAVIS_BUILD_DIR
-  - ./gradlew --console=plain release
+  - ./gradlew --console=plain releaseBinaries
   - ./tools/travis/test_openwhisk.sh
 
 after_success:

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ class OpenWhiskPlatform {
         The 'zipFileName' property is the root file name to use for archives.
      */
     static String zipFileName
-    static String packageVersion
 
     /*
         Create a platform for the local platform
@@ -122,9 +121,8 @@ OpenWhiskPlatform.zipFileName =
     System.env['zip_file_name'] ?:
         (rootProject.findProperty('zipFileName') ?: 'OpenWhisk_CLI')
 
-OpenWhiskPlatform.packageVersion =
-        System.env['packageVersion'] ?:
-                (rootProject.findProperty('packageVersion') ?: 'latest')
+project.ext.packageVersion =
+        rootProject.findProperty('packageVersion') ?: 'latest'
 
 String buildFileName = System.env['build_file_name'] ?:
         (rootProject.findProperty('buildFileName') ?: 'wsk')
@@ -219,7 +217,7 @@ task individualArchives(
             type: (p.goOs == 'linux') ? Tar : Zip, dependsOn: compile) {
                 if (p.goOs == 'linux') { compression = Compression.GZIP }
                 destinationDir = file('./release')
-                baseName = "${p.zipFileName}-${p.packageVersion}-${p.owOs}-${p.goArch}"
+                baseName = "${p.zipFileName}-${packageVersion}-${p.owOs}-${p.goArch}"
                 from "./build/${p.goOs}-${p.goArch}/"
                 include "${buildFileName}*"
             }
@@ -251,11 +249,11 @@ task index() {
 task releaseBinaries(type: Tar, dependsOn: [individualArchives, index]) {
     compression = Compression.GZIP
     destinationDir = file('./release')
-    baseName = "${OpenWhiskPlatform.zipFileName}-${OpenWhiskPlatform.packageVersion}-all"
+    baseName = "${OpenWhiskPlatform.zipFileName}-${packageVersion}-all"
     from('./build/content.json') { into('.') }
     rootProject.platforms.each() { p ->
         from('./release/') {
-            include("${p.zipFileName}-${p.packageVersion}-${p.owOs}-${p.goArch}.*")
+            include("${p.zipFileName}-${packageVersion}-${p.owOs}-${p.goArch}.*")
             into p.archiveDirName
             rename { p.archiveFileName }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ class OpenWhiskPlatform {
         The 'zipFileName' property is the root file name to use for archives.
      */
     static String zipFileName
+    static String packageVersion
 
     /*
         Create a platform for the local platform
@@ -120,6 +121,10 @@ class OpenWhiskPlatform {
 OpenWhiskPlatform.zipFileName =
     System.env['zip_file_name'] ?:
         (rootProject.findProperty('zipFileName') ?: 'OpenWhisk_CLI')
+
+OpenWhiskPlatform.packageVersion =
+        System.env['packageVersion'] ?:
+                (rootProject.findProperty('packageVersion') ?: 'latest')
 
 String buildFileName = System.env['build_file_name'] ?:
         (rootProject.findProperty('buildFileName') ?: 'wsk')
@@ -214,7 +219,7 @@ task individualArchives(
             type: (p.goOs == 'linux') ? Tar : Zip, dependsOn: compile) {
                 if (p.goOs == 'linux') { compression = Compression.GZIP }
                 destinationDir = file('./release')
-                baseName = "${p.zipFileName}-latest-${p.owOs}-${p.goArch}"
+                baseName = "${p.zipFileName}-${p.packageVersion}-${p.owOs}-${p.goArch}"
                 from "./build/${p.goOs}-${p.goArch}/"
                 include "${buildFileName}*"
             }
@@ -243,14 +248,14 @@ task index() {
     }
 }
 
-task release(type: Tar, dependsOn: [individualArchives, index]) {
+task releaseBinaries(type: Tar, dependsOn: [individualArchives, index]) {
     compression = Compression.GZIP
     destinationDir = file('./release')
-    baseName = "${OpenWhiskPlatform.zipFileName}-latest-all"
+    baseName = "${OpenWhiskPlatform.zipFileName}-${OpenWhiskPlatform.packageVersion}-all"
     from('./build/content.json') { into('.') }
     rootProject.platforms.each() { p ->
         from('./release/') {
-            include("${p.zipFileName}-latest-${p.owOs}-${p.goArch}.*")
+            include("${p.zipFileName}-${p.packageVersion}-${p.owOs}-${p.goArch}.*")
             into p.archiveDirName
             rename { p.archiveFileName }
         }

--- a/tools/travis/test_openwhisk.sh
+++ b/tools/travis/test_openwhisk.sh
@@ -7,7 +7,7 @@ set -e
 #  the release.  If you're running manually, this command should get you to
 #  the same place:
 #
-#    ./gradlew release
+#    ./gradlew releaseBinaries
 #
 #  Also at this point, you should already have incubator-openwhisk pulled down
 #  from gradle in the parent directory, using a command such as:


### PR DESCRIPTION
This PR changes the task name from release to releaseBinaries in
order to make it consistent in the release process. It also adds
packageVersion as a parameter to specify the version of the binaries
to be released.

Partially-closes: apache/incubator-openwhisk-release#9