### PR TITLE
Update the commit time for the the tag "latest"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,8 @@ after_success:
       git config --global user.name "Travis CI";
       export GIT_TAG="latest";
       git tag -d $GIT_TAG;
-      git tag $GIT_TAG -a -m "Generated tag from Travis CI build $TRAVIS_BUILD_NUMBER";
+      git push -q https://$API_KEY@github.com/apache/incubator-openwhisk-cli :refs/tags/$GIT_TAG;
+      GIT_COMMITTER_DATE="$(git show --format=%aD | head -1)" git tag $GIT_TAG -a -m "Generated tag from Travis CI build $TRAVIS_BUILD_NUMBER";
       git push -f -q https://$API_KEY@github.com/apache/incubator-openwhisk-cli $GIT_TAG;
     fi
 


### PR DESCRIPTION
Each time the commit is changed for the tag "latest", the commit
time remains to be the initial time when the tag is created for
the first time. This PR makes it able to change when the tag "latest"
is updated.