### PR TITLE
Add the LICENSE and NOTICE files into the binary packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,11 @@ script:
   - cd $TRAVIS_BUILD_DIR/../incubator-openwhisk
   - ./gradlew install
   - cd $TRAVIS_BUILD_DIR
-  - ./gradlew --console=plain releaseBinaries
+  - export BUILD_VERSION="latest"
+  - if [ ! -z "$TRAVIS_TAG" ] ; then
+        export BUILD_VERSION=$TRAVIS_TAG;
+    fi
+  - ./gradlew --console=plain releaseBinaries -PpackageVersion=$BUILD_VERSION
   - ./tools/travis/test_openwhisk.sh
 
 after_success:
@@ -73,16 +77,6 @@ before_deploy:
   - echo "Deploying $RELEASE_PKG_FILE to GitHub releases."
   - export GIT_TAG="latest"
   - export TAG=false;
-  # This tag is automatically generated for the latest merged commit in master branch.
-  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ "$TRAVIS_OS_NAME" == "linux" ] ; then
-      git config --global user.email "builds@travis-ci.com";
-      git config --global user.name "Travis CI";
-      export GIT_TAG="latest";
-      git tag -d $GIT_TAG;
-      git push -q https://$API_KEY@github.com/apache/incubator-openwhisk-cli :refs/tags/$GIT_TAG;
-      GIT_COMMITTER_DATE="$(git show --format=%aD | head -1)" git tag $GIT_TAG -a -m "Generated tag from Travis CI build $TRAVIS_BUILD_NUMBER";
-      git push -f -q https://$API_KEY@github.com/apache/incubator-openwhisk-cli $GIT_TAG;
-    fi
   - if [ ! -z "$TRAVIS_TAG" ] ; then
       export GIT_TAG=$TRAVIS_TAG;
       export TAG=true;

--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,9 @@ task individualArchives(
                 baseName = "${p.zipFileName}-${packageVersion}-${p.owOs}-${p.goArch}"
                 from "./build/${p.goOs}-${p.goArch}/"
                 include "${buildFileName}*"
+                from "./"
+                include "LICENSE.txt", "NOTICE.txt", "README.md"
+                exclude "wski18n"
             }
     })
 


### PR DESCRIPTION
This PR adds the LICENSE, NOTICE and README into the binary packages. In addition, it also removes the dependency to generate the i18n resource. It is the responsibility of the project to provide the i18n resource to the users, so that users do not have to generate the i18n resource file on themselves.