### PR TITLE
Bump go-client to handle error code (tid) not as int.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
         build(['name':'golang.org/x/sys/unix', 'version':'7f918dd405547ecb864d14a8ecbbfe205b5f930f', 'transitive':false])
         build(['name':'gopkg.in/yaml.v2', 'version':'cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b', 'transitive':false])
         build(['name':'github.com/ghodss/yaml', 'version':'0ca9ea5df5451ffdf184b4428c902747c2c11cd7', 'transitive':false])
-        build(['name':'github.com/apache/incubator-openwhisk-client-go/whisk','version':'e4b5f823ee5e29e2598381e8013d572f78d443f5','transitive':false])
+        build(['name':'github.com/apache/incubator-openwhisk-client-go/whisk','version':'3d62dac688b8efa88f924658a9ac8f1058fed4ea','transitive':false])
         // END - Imported from Godeps
         test name:'github.com/stretchr/testify', version:'b91bfb9ebec76498946beb6af7c0230c7cc7ba6c', transitive:false //, tag: 'v1.2.0'
         test name:'github.com/spf13/viper', version:'aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5', transitive:false


### PR DESCRIPTION
As the tid will not be handled as int in the future anymore, this PR changes this assumption in the CLI.

Related PR in the core repository: apache/incubator-openwhisk#3199