### PR TITLE
Add retries to log integration test

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -392,13 +392,15 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       }
 
       withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
-        val cmd = Seq("activation", "logs", "--strip", activation.activationId)
-        val run = wsk.cli(cmd ++ wskprops.overrides ++ auth,
-                          expectedExitCode = SUCCESS_EXIT)
-        run.stdout should {
-          be("this is stdout\nthis is stderr\n") or
-            be("this is stderr\nthis is stdout\n")
-        }
+        retry({
+          val cmd = Seq("activation", "logs", "--strip", activation.activationId)
+          val run = wsk.cli(cmd ++ wskprops.overrides ++ auth,
+                            expectedExitCode = SUCCESS_EXIT)
+          run.stdout should {
+            be("this is stdout\nthis is stderr\n") or
+              be("this is stderr\nthis is stdout\n")
+          }
+        }, 10, Some(1.second))
       }
   }
 


### PR DESCRIPTION
Prevents intermittent failures from eventual consistent databases.