### PR TITLE
Wait for 2 minutes for logs.

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -400,7 +400,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
             be("this is stdout\nthis is stderr\n") or
               be("this is stderr\nthis is stdout\n")
           }
-        }, 10, Some(1.second))
+        }, 120, Some(1.second))
       }
   }
 


### PR DESCRIPTION
Increase time to wait for logs, to handle potential delays, that could occure, depending on the store, that is used to store logs.