### PR TITLE
Bug fix: Use configured prototcol for API requests

### DIFF
--- a/commands/api.go
+++ b/commands/api.go
@@ -913,7 +913,11 @@ func parseApi(cmd *cobra.Command, args []string) (*whisk.Api, *QualifiedName, er
 	} else {
 		urlActionPackage = "default"
 	}
-	api.Action.BackendUrl = "https://" + Client.Config.Host + "/api/v1/web/" + qName.GetNamespace() + "/" + urlActionPackage + "/" + qName.GetEntity() + ".http"
+	backendUrl := Client.Config.Host + "/api/v1/web/" + qName.GetNamespace() + "/" + urlActionPackage + "/" + qName.GetEntity() + ".http"
+	if !strings.HasPrefix(backendUrl, "http") {
+		backendUrl = "https://" + backendUrl
+	}
+	api.Action.BackendUrl = backendUrl
 	api.Action.BackendMethod = api.GatewayMethod
 	api.Action.Name = qName.GetEntityName()
 	api.Action.Namespace = qName.GetNamespace()


### PR DESCRIPTION
Add check to see if Client.Config.Host already specifies the protocol
to use before prepending https:// in URL construction.
Fixes a bug where if .wskprops specifies a APIHOST with a protocol,
`wsk api create` generates an invalid backend URL (https://https://APIHOST/...).

Fixes #125.