### PR TITLE
Run unit and native tests separately

### DIFF
--- a/tools/travis/test_openwhisk.sh
+++ b/tools/travis/test_openwhisk.sh
@@ -73,7 +73,8 @@ cd $TRAVIS_BUILD_DIR
 #
 #  Run Unit and native tests
 #
-./gradlew --console=plain --info goTest -PgoTags=unit,native
+./gradlew --console=plain --info goTest -PgoTags=unit
+./gradlew --console=plain --info goTest -PgoTags=native
 
 #
 #  Set up the OpenWhisk environment for integration testing


### PR DESCRIPTION
`./gradlew --console=plain --info goTest -PgoTags=unit,native` does not run native or unit tests, so running unit and native individually.