### PR TITLE
Separate the source directories for different files to package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,11 +241,13 @@ task individualArchives(
                 if (p.goOs == 'linux') { compression = Compression.GZIP }
                 destinationDir = file(cliReleaseLocation)
                 baseName = "${p.zipFileName}-${packageVersion}-${p.owOs}-${p.goArch}"
-                from "${cliBuildLocation}/${p.goOs}-${p.goArch}/"
-                include "${buildFileName}*"
-                from "./"
-                include "LICENSE.txt", "NOTICE.txt", "README.md"
-                exclude "wski18n"
+                from("${cliBuildLocation}/${p.goOs}-${p.goArch}/") {
+                    include "${buildFileName}*"
+                }
+                from("./") {
+                    include "LICENSE.txt", "NOTICE.txt", "README.md"
+                    exclude "wski18n"
+                }
             }
     })
 


### PR DESCRIPTION
We need to pick up the files to package from different directories
by specifying separately, in order to remove conflict.