### PR TITLE
Refactor trigger create using new utility methods to factor out printing of the feed action result

### DIFF
--- a/commands/messages.go
+++ b/commands/messages.go
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package commands
+
+/**
+ * Mapping from identifiers to message ids in wski18n resources.
+ *
+ * NOTE: this list is not complete as message will be moved incrementally.
+ */
+const (
+	FEED_CONFIGURATION_FAILURE = "FEED_CONFIGURATION_FAILURE"
+)

--- a/tests/src/integration/integration_test.go
+++ b/tests/src/integration/integration_test.go
@@ -42,7 +42,6 @@ var ruleTriggerActionReqMsg = "A rule, trigger and action name are required."
 var activationIdReq = "An activation ID is required."
 var triggerNameReqMsg = "A trigger name is required."
 var optNamespaceMsg = "An optional namespace is the only valid argument."
-var optPayloadMsg = "A payload is optional."
 var noArgsReqMsg = "No arguments are required."
 var invalidArg = "invalidArg"
 var apiCreateReqMsg = "Specify a swagger file or specify an API base path with an API path, an API verb, and an action name."
@@ -282,11 +281,11 @@ func initInvalidArgs() {
 
 		{
 			Cmd: []string{"trigger", "fire"},
-			Err: tooFewArgsMsg + " " + triggerNameReqMsg + " " + optPayloadMsg,
+			Err: tooFewArgsMsg + " " + triggerNameReqMsg,
 		},
 		{
-			Cmd: []string{"trigger", "fire", "triggerName", "triggerPayload", invalidArg},
-			Err: tooManyArgsMsg + invalidArg + ". " + triggerNameReqMsg + " " + optPayloadMsg,
+			Cmd: []string{"trigger", "fire", "triggerName", invalidArg},
+			Err: tooManyArgsMsg + invalidArg + ". " + triggerNameReqMsg,
 		},
 		{
 			Cmd: []string{"trigger", "create"},

--- a/tests/src/test/scala/whisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -2257,7 +2257,6 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
     val activationIdReq = "An activation ID is required."
     val triggerNameReqMsg = "A trigger name is required."
     val optNamespaceMsg = "An optional namespace is the only valid argument."
-    val optPayloadMsg = "A payload is optional."
     val noArgsReqMsg = "No arguments are required."
     val invalidArg = "invalidArg"
     val apiCreateReqMsg =
@@ -2389,9 +2388,9 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
        s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
       (Seq("rule", "list", invalidArg), entityNameMsg),
       (Seq("trigger", "fire"),
-       s"${tooFewArgsMsg} ${triggerNameReqMsg} ${optPayloadMsg}"),
-      (Seq("trigger", "fire", "triggerName", "triggerPayload", invalidArg),
-       s"${tooManyArgsMsg}${invalidArg}. ${triggerNameReqMsg} ${optPayloadMsg}"),
+       s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
+      (Seq("trigger", "fire", "triggerName", invalidArg),
+        s"${tooManyArgsMsg}${invalidArg}. ${triggerNameReqMsg}"),
       (Seq("trigger", "create"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
       (Seq("trigger", "create", "triggerName", invalidArg),
        s"${tooManyArgsMsg}${invalidArg}."),

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -687,8 +687,8 @@
     "translation": "Unable to obtain the list of triggers for namespace '{{.name}}': {{.err}}"
   },
   {
-    "id": "Unable to invoke trigger '{{.trigname}}' feed action '{{.feedname}}'; feed is not configured: {{.err}}",
-    "translation": "Unable to invoke trigger '{{.trigname}}' feed action '{{.feedname}}'; feed is not configured: {{.err}}"
+    "id": "FEED_CONFIGURATION_FAILURE",
+    "translation": "Unable to configure feed '{{.feedname}}': {{.err}}"
   },
   {
     "note-to-translators": "DO NOT TRANSLATE THE 'yes' AND 'no'.  THOSE ARE FIXED CLI ARGUMENT VALUES",


### PR DESCRIPTION
Add a method for working with parameters and annotations, and creating the feed life cycle event.
This is intended as an incremental change that is mostly semantic preserving. Because of the extent of refactoring needed, I staged all the commits incrementally and each is logically complete. 

This PR builds of #319 and adds 3 new commits. The commits are all grouped for ease of reviewing.

Part of #314.