### PR TITLE
Refactor action invoke functions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ incubator-openwhisk-cli.iml
 wski18n/i18n_resources.go
 bin/
 tests/build/
+tests/out/

--- a/commands/action.go
+++ b/commands/action.go
@@ -171,10 +171,7 @@ var actionInvokeCmd = &cobra.Command{
 			return NewQualifiedNameError(args[0], err)
 		}
 
-		if parameters, err = getParameters(Flags.common.param); err != nil {
-			return err
-		}
-
+		parameters = getParameters(Flags.common.param, false, false)
 		blocking := Flags.common.blocking || Flags.action.result
 		resultOnly := Flags.action.result
 		header := !resultOnly
@@ -186,18 +183,6 @@ var actionInvokeCmd = &cobra.Command{
 			resultOnly)
 		return handleInvocationResponse(*qualifiedName, blocking, header, res, err)
 	},
-}
-
-func getParameters(params []string) (interface{}, error) {
-	var parameters interface{}
-	var err error
-
-	if len(params) > 0 {
-		if parameters, err = getJSONFromStrings(params, false); err != nil {
-			return nil, getJSONFromStringsParamError(params, false, err)
-		}
-	}
-	return parameters, nil
 }
 
 func invokeAction(

--- a/commands/trigger.go
+++ b/commands/trigger.go
@@ -524,7 +524,7 @@ func configureFeed(triggerName string, feedName string, parameters interface{}) 
 	}
 
 	res, err := invokeAction(*fullFeedName, parameters, true, false)
-	err = handleInvocationResponse(*fullFeedName, true, false, res, err)
+	err = printInvocationResponse(*fullFeedName, true, false, res, err)
 
 	if err != nil {
 		whisk.Debug(whisk.DbgError, "Invoke of action '%s' failed: %s\n", feedName, err)

--- a/commands/trigger.go
+++ b/commands/trigger.go
@@ -193,7 +193,7 @@ var triggerCreateCmd = &cobra.Command{
 
 		// Invoke the specified feed action to configure the trigger feed
 		if feedArgPassed {
-			err := configureFeed(trigger.Name, fullFeedName)
+			err := configureFeed(trigger.Name, fullFeedName, getParameters(Flags.common.param, false, false))
 			if err != nil {
 				whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", trigger.Name, Flags.common.feed,
 					err)
@@ -286,7 +286,7 @@ var triggerUpdateCmd = &cobra.Command{
 			Flags.common.param = append(Flags.common.param, getFormattedJSON(FEED_AUTH_KEY, Client.Config.AuthToken))
 
 			// Invoke the specified feed action to configure the trigger feed
-			err = configureFeed(qualifiedName.GetEntityName(), fullFeedName)
+			err = configureFeed(qualifiedName.GetEntityName(), fullFeedName, getParameters(Flags.common.param, false, false))
 			if err != nil {
 				whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", qualifiedName.GetEntityName(), Flags.common.feed,
 					err)
@@ -372,7 +372,7 @@ var triggerGetCmd = &cobra.Command{
 			Flags.common.param = append(Flags.common.param, getFormattedJSON(FEED_TRIGGER_NAME, fullTriggerName))
 			Flags.common.param = append(Flags.common.param, getFormattedJSON(FEED_AUTH_KEY, Client.Config.AuthToken))
 
-			err = configureFeed(qualifiedName.GetEntityName(), fullFeedName)
+			err = configureFeed(qualifiedName.GetEntityName(), fullFeedName, getParameters(Flags.common.param, false, false))
 			if err != nil {
 				whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", qualifiedName.GetEntityName(), fullFeedName, err)
 			}
@@ -441,7 +441,7 @@ var triggerDeleteCmd = &cobra.Command{
 				Flags.common.param = append(Flags.common.param, getFormattedJSON(FEED_TRIGGER_NAME, fullTriggerName))
 				Flags.common.param = append(Flags.common.param, getFormattedJSON(FEED_AUTH_KEY, Client.Config.AuthToken))
 
-				err = configureFeed(qualifiedName.GetEntityName(), fullFeedName)
+				err = configureFeed(qualifiedName.GetEntityName(), fullFeedName, getParameters(Flags.common.param, false, false))
 				if err != nil {
 					whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", qualifiedName.GetEntityName(), fullFeedName, err)
 				}
@@ -515,17 +515,12 @@ var triggerListCmd = &cobra.Command{
 	},
 }
 
-func configureFeed(triggerName string, feedName string) error {
+func configureFeed(triggerName string, feedName string, parameters interface{}) error {
 	var fullFeedName *QualifiedName
-	var parameters interface{}
 	var err error
 
 	if fullFeedName, err = NewQualifiedName(feedName); err != nil {
 		return NewQualifiedNameError(feedName, err)
-	}
-
-	if parameters, err = getParameters(Flags.common.param); err != nil {
-		return err
 	}
 
 	res, err := invokeAction(*fullFeedName, parameters, true, false)

--- a/main.go
+++ b/main.go
@@ -19,15 +19,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/fatih/color"
 	goi18n "github.com/nicksnyder/go-i18n/i18n"
 	"os"
-	"reflect"
 
 	"github.com/apache/incubator-openwhisk-cli/commands"
 	"github.com/apache/incubator-openwhisk-cli/wski18n"
 	"github.com/apache/incubator-openwhisk-client-go/whisk"
-	"github.com/mattn/go-colorable"
 )
 
 // CLI_BUILD_TIME holds the time of the CLI build.  During gradle builds,
@@ -51,12 +48,6 @@ func init() {
 }
 
 func main() {
-	var exitCode int = 0
-	var displayUsage bool = false
-	var displayMsg bool = false
-	var msgDisplayed bool = true
-	var displayPrefix bool = true
-
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Println(r)
@@ -65,42 +56,7 @@ func main() {
 	}()
 
 	if err := commands.Execute(); err != nil {
-		whisk.Debug(whisk.DbgInfo, "err object type: %s\n", reflect.TypeOf(err).String())
-
-		werr, isWskError := err.(*whisk.WskError) // Is the err a WskError?
-		if isWskError {
-			whisk.Debug(whisk.DbgError, "Got a *whisk.WskError error: %#v\n", werr)
-			displayUsage = werr.DisplayUsage
-			displayMsg = werr.DisplayMsg
-			msgDisplayed = werr.MsgDisplayed
-			displayPrefix = werr.DisplayPrefix
-			exitCode = werr.ExitCode
-		} else {
-			whisk.Debug(whisk.DbgError, "Got some other error: %s\n", err)
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-
-			displayUsage = false // Cobra already displayed the usage message
-			exitCode = 1
-		}
-
-		outputStream := colorable.NewColorableStderr()
-
-		// If the err msg should be displayed to the console and it has not already been
-		// displayed, display it now.
-		if displayMsg && !msgDisplayed && displayPrefix && exitCode != 0 {
-			fmt.Fprintf(outputStream, "%s%s\n", color.RedString(T("error: ")), err)
-		} else if displayMsg && !msgDisplayed && !displayPrefix && exitCode != 0 {
-			fmt.Fprintf(outputStream, "%s\n", err)
-		} else if displayMsg && !msgDisplayed && exitCode == 0 {
-			fmt.Fprintf(outputStream, "%s\n", err)
-		}
-
-		// Displays usage
-		if displayUsage {
-			fmt.Fprintf(outputStream, T("Run '{{.Name}} --help' for usage.\n",
-				map[string]interface{}{"Name": commands.WskCmd.CommandPath()}))
-		}
+		commands.ExitOnError(err)
 	}
-	os.Exit(exitCode)
 	return
 }


### PR DESCRIPTION
This permits a caller to determine how it wants to handle the action activation response. This is toward removing the feed output when creating a trigger with a feed.

The commits are all grouped and incremental for ease of reviewing.

This is related to fixing https://github.com/apache/incubator-openwhisk-cli/issues/134.