### PR TITLE
Fix failing config test

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
@@ -46,7 +46,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
     try {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       wsk.cli(Seq("property", "set", "-i", "--apihost", "xxxx.yyyy"), env = env)
-      val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env, expectedExitCode = ANY_ERROR_EXIT)
+      val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env, expectedExitCode = NETWORK_ERROR_EXIT)
       rr.stdout should include regex ("""whisk API build\s*Unknown""")
       rr.stderr should include regex ("Unable to obtain API build information")
     } finally {


### PR DESCRIPTION
`fail to show api build when setting apihost to bogus value` is failing as it should expect a `NETWORK_ERROR_EXIT` exit code.

Result of retry logic for non-expected network errors: https://github.com/apache/incubator-openwhisk/commit/f4d8ce5009381cdf3385a69c383eca2fd01a0282.