### PR TITLE
Bump Gradle version to 4.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,4 +5,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip


### PR DESCRIPTION
As part of getting the CLI in Homebrew https://github.com/Homebrew/homebrew-core/pull/31231 I kept getting the following error:

```
Unzipping /Users/brew/Library/Caches/Homebrew/java_cache/.gradle/wrapper/dists/gradle-4.1-bin/c3kp51zwwt108wc78u68yt7vs/gradle-4.1-bin.zip to /Users/brew/Library/Caches/Homebrew/java_cache/.gradle/wrapper/dists/gradle-4.1-bin/c3kp51zwwt108wc78u68yt7vs
Set executable permissions for: /Users/brew/Library/Caches/Homebrew/java_cache/.gradle/wrapper/dists/gradle-4.1-bin/c3kp51zwwt108wc78u68yt7vs/gradle-4.1/bin/gradle

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine java version from '10.0.1'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org
```

See full log here: https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/29084/version=el_capitan/testReport/junit/brew-test-bot/el_capitan/install_wsk/

After some DuckDuckGo'ing it seems that this is a problem with [Gradle versions around the 4.1 mark](https://discuss.gradle.org/t/could-not-determine-java-version-from-9-0-1/24457/4) and upgrading seemed to be the solution.
I added [a hack](https://github.com/Homebrew/homebrew-core/pull/31231/commits/b879b01e8940b9113bd1dd2e53ac2515da41ea01) for the Homebrew formula to get it using a later version of Gradle and that seemed to work fine.

I'd like to bump up the version here so I can remove the hack and so people don't experience this issue when compiling the CLI.
