### PR TITLE
Add Govendor as the preferred way of installing dependencies for Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ Godeps/_workspace
 /.gogradle/
 build
 /release/
-/vendor/
+/vendor/*/
 incubator-openwhisk-cli.iml
 wski18n/i18n_resources.go
 bin/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 -->
 
 # OpenWhisk Command Line Interface `wsk`
+
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-cli.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-cli)
 
@@ -36,14 +37,14 @@ The OpenWhisk CLI is written in the Go language. You have two options to build
 the binary locally:
 
 1.  Build using the packaged Gradle scripts (including the 'gogradle' plugin),
-now the preferred build method.
+    now the preferred build method.
 2.  Compile in your local Go environment,
 
 ## Build the binary with Gradle
 
 **Note:** For those who may have used the Gradle build previously, it has been
 re-engineered to no longer required Docker or Go to be pre-installed on your
-system.  Using the [gogradle](https://github.com/gogradle/gogradle) plugin,
+system. Using the [gogradle](https://github.com/gogradle/gogradle) plugin,
 Gradle now uses a prexisting Go environment to build if it can be located, or
 downloads and installs an environment within the build directory.
 
@@ -125,11 +126,12 @@ $ go-bindata -pkg wski18n -o wski18n/i18n_resources.go wski18n/resources
 ```
 
 Unfortunately, it has become necessary to lock dependencies versions to obtain a
-clean build of wsk.  To that end, it's now necessary to populate the `vendors`
-folder using the versions selected in the `build.gradle`:
+clean build of wsk. To that end, it's now necessary to populate the `vendors`
+folder using the versions selected in the `vendor/vendor.json`:
 
-```
-$ ./gradlew goVendor
+```sh
+$ go get -u github.com/kardianos/govendor         # Install govendor tool
+$ govendor sync     # Download and install packages with specified dependencies.
 ```
 
 Once vendor is populated, it's possible to build the binary:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,121 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "ASp79qek5lZJ18lexnxnnw8wQSs=",
+			"path": "github.com/apache/incubator-openwhisk-client-go/whisk",
+			"revision": "d7cee96e83a1f38413a1f5286bd524dac72686c9",
+			"revisionTime": "2018-08-03T16:52:51Z"
+		},
+		{
+			"checksumSHA1": "4NY5lFykxXaoN+JNMxo179L79sU=",
+			"path": "github.com/apache/incubator-openwhisk-client-go/wski18n",
+			"revision": "d7cee96e83a1f38413a1f5286bd524dac72686c9",
+			"revisionTime": "2018-08-03T16:52:51Z"
+		},
+		{
+			"checksumSHA1": "A/DjlgGYOKIkKC8qckZB1shNTFk=",
+			"path": "github.com/cloudfoundry/jibber_jabber",
+			"revision": "bcc4c8345a21301bf47c032ff42dd1aae2fe3027",
+			"revisionTime": "2015-11-20T18:32:58Z"
+		},
+		{
+			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
+			"path": "github.com/fatih/color",
+			"revision": "570b54cabe6b8eb0bc2dfce68d964677d63b5260",
+			"revisionTime": "2017-05-23T13:53:55Z"
+		},
+		{
+			"checksumSHA1": "nQqAEaB3gBG9PSKYZTbQ5IiN3jo=",
+			"path": "github.com/ghodss/yaml",
+			"revision": "e9ed3c6dfb39bb1a32197cb10d527906fe4da4b6",
+			"revisionTime": "2018-05-03T02:20:59Z"
+		},
+		{
+			"checksumSHA1": "yyAzHoiVLu+xywYI2BDyRq6sOqE=",
+			"path": "github.com/google/go-querystring/query",
+			"revision": "9235644dd9e52eeae6fa48efd539fdc351a0af53",
+			"revisionTime": "2016-03-11T01:20:12Z"
+		},
+		{
+			"checksumSHA1": "TuS7rrLDK41z7LMgbcET4O8uMj4=",
+			"path": "github.com/hokaccha/go-prettyjson",
+			"revision": "f75235bd99dad4e98ff360db8372d5c0ef1d054a",
+			"revisionTime": "2014-12-01T06:53:30Z"
+		},
+		{
+			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
+			"path": "github.com/inconshreveable/mousetrap",
+			"revision": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
+			"revisionTime": "2014-10-17T20:07:13Z"
+		},
+		{
+			"checksumSHA1": "I4njd26dG5hxFT2nawuByM4pxzY=",
+			"path": "github.com/mattn/go-colorable",
+			"revision": "d228849504861217f796da67fae4f6e347643f15",
+			"revisionTime": "2016-11-03T16:00:40Z"
+		},
+		{
+			"checksumSHA1": "xZuhljnmBysJPta/lMyYmJdujCg=",
+			"path": "github.com/mattn/go-isatty",
+			"revision": "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8",
+			"revisionTime": "2016-08-06T12:27:52Z"
+		},
+		{
+			"checksumSHA1": "Li0PaRmaVBdibS/zs8myzc07L6o=",
+			"path": "github.com/mitchellh/go-homedir",
+			"revision": "58046073cbffe2f25d425fe1331102f55cf719de",
+			"revisionTime": "2018-08-01T23:32:06Z"
+		},
+		{
+			"checksumSHA1": "uEc9/1HbYGeK7wPStF6FmUlfzGE=",
+			"path": "github.com/nicksnyder/go-i18n/i18n",
+			"revision": "991e81cc94f6c54209edb3192cb98e3995ad71c1",
+			"revisionTime": "2016-11-05T14:54:59Z"
+		},
+		{
+			"checksumSHA1": "S1YUq0Ts6uu44Krqwgqon0/hNWg=",
+			"path": "github.com/nicksnyder/go-i18n/i18n/bundle",
+			"revision": "991e81cc94f6c54209edb3192cb98e3995ad71c1",
+			"revisionTime": "2016-11-05T14:54:59Z"
+		},
+		{
+			"checksumSHA1": "+XOg99I1zdmBRUb04ZswvzQ2WS0=",
+			"path": "github.com/nicksnyder/go-i18n/i18n/language",
+			"revision": "991e81cc94f6c54209edb3192cb98e3995ad71c1",
+			"revisionTime": "2016-11-05T14:54:59Z"
+		},
+		{
+			"checksumSHA1": "nhlpSPeAP6jMGAuLPM2xflAZTlo=",
+			"path": "github.com/nicksnyder/go-i18n/i18n/translation",
+			"revision": "991e81cc94f6c54209edb3192cb98e3995ad71c1",
+			"revisionTime": "2016-11-05T14:54:59Z"
+		},
+		{
+			"checksumSHA1": "FZ0r4TzEy9UxXLkFVXFygApni4M=",
+			"path": "github.com/spf13/cobra",
+			"revision": "6e91dded25d73176bf7f60b40dd7aa1f0bf9be8d",
+			"revisionTime": "2016-10-26T01:28:26Z"
+		},
+		{
+			"checksumSHA1": "GxPD7A0NjMDom1xte0mghkpzr0E=",
+			"path": "github.com/spf13/pflag",
+			"revision": "5ccb023bc27df288a957c5e994cd44fd19619465",
+			"revisionTime": "2016-10-24T13:13:51Z"
+		},
+		{
+			"checksumSHA1": "2e4afOQfHP7YB4P68v6SlnAVJDk=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "9a2e24c3733eddc63871eda99f253e2db29bd3b9",
+			"revisionTime": "2016-11-08T14:26:43Z"
+		},
+		{
+			"checksumSHA1": "RDJpJQwkF012L6m/2BJizyOksNw=",
+			"path": "gopkg.in/yaml.v2",
+			"revision": "eb3733d160e74a9c7e442f435eb3bea458e1d19f",
+			"revisionTime": "2017-08-12T16:00:11Z"
+		}
+	],
+	"rootPath": "github.com/apache/incubator-openwhisk-cli"
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -105,7 +105,7 @@
 			"revisionTime": "2016-10-24T13:13:51Z"
 		},
 		{
-			"checksumSHA1": "2e4afOQfHP7YB4P68v6SlnAVJDk=",
+			"checksumSHA1": "UP4jCCzMRwJ78B+G1Mf5E4/81A4=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "9a2e24c3733eddc63871eda99f253e2db29bd3b9",
 			"revisionTime": "2016-11-08T14:26:43Z"


### PR DESCRIPTION
Adding in a native to Go dependency manager. 
This allows people to not have to go through Gradle if they are doing everything in Go anyway.

Homebrew also requires a native Go dependency manager as opposed to Gradle: https://github.com/Homebrew/homebrew-core/pull/31231

I also looked at [godep](https://github.com/tools/godep) since `wskdeploy` is currently also using that. But according to Godep's own website the project has be Archived and is no longer maintained. This in favor of the many other dependency manager tools.

During my hunt for a Go dependency manager I looked at a number of popular ones including Glide. And eventually I choose govendor because it is very actively being updated and the installation process seemed less involved (`go get ...`) than many other package managers.