### PR TITLE
Allow API GW access token override

### DIFF
--- a/commands/api.go
+++ b/commands/api.go
@@ -1014,9 +1014,9 @@ func getAccessToken() (string, error) {
 	var err error
 
 	// If the api gw access token override has been set, use it instead of the default
-	whisk.Debug(whisk.DbgInfo, "api gw access token override is '%s'\n", ApiGwAccessToken)
 	if len(ApiGwAccessToken) > 0 {
 		token = ApiGwAccessToken
+		whisk.Debug(whisk.DbgInfo, "API GW access token override used\n")
 	} else {
 		props, errprops := ReadProps(Properties.PropsFile)
 		if errprops == nil {

--- a/commands/api.go
+++ b/commands/api.go
@@ -1019,8 +1019,8 @@ func getAccessToken() (string, error) {
 		token = ApiGwAccessToken
 		whisk.Debug(whisk.DbgInfo, "Using %s as the api gw access token\n", token)
 	} else {
-		props, err := ReadProps(Properties.PropsFile)
-		if err == nil {
+		props, errprops := ReadProps(Properties.PropsFile)
+		if errprops == nil {
 			if len(props["APIGW_ACCESS_TOKEN"]) > 0 {
 				token = props["APIGW_ACCESS_TOKEN"]
 			}

--- a/commands/api.go
+++ b/commands/api.go
@@ -1017,7 +1017,6 @@ func getAccessToken() (string, error) {
 	whisk.Debug(whisk.DbgInfo, "api gw access token override is '%s'\n", ApiGwAccessToken)
 	if len(ApiGwAccessToken) > 0 {
 		token = ApiGwAccessToken
-		whisk.Debug(whisk.DbgInfo, "Using %s as the api gw access token\n", token)
 	} else {
 		props, errprops := ReadProps(Properties.PropsFile)
 		if errprops == nil {

--- a/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
@@ -269,7 +269,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
     val tmpwskprops = File.createTempFile("wskprops", ".tmp")
     try {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-      val apihost = s"http://${WhiskProperties.getBaseControllerAddress()}"
+      val apihost = s"${WhiskProperties.getProperty("controller.protocol")}://${WhiskProperties.getBaseControllerHost()}"
       wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
       rr.stdout should not include regex("""whisk API build\s*Unknown""")

--- a/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
@@ -269,7 +269,8 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
     val tmpwskprops = File.createTempFile("wskprops", ".tmp")
     try {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-      val apihost = s"${WhiskProperties.getProperty("controller.protocol")}://${WhiskProperties.getBaseControllerHost()}"
+      val apihost =
+        s"${WhiskProperties.getProperty("controller.protocol")}://${WhiskProperties.getBaseControllerHost()}"
       wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
       rr.stdout should not include regex("""whisk API build\s*Unknown""")


### PR DESCRIPTION
- Can change API GW authentication from basic auth to another `Authorization` header value.