### PR TITLE
Switch to Scala 2.12.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
   - test -z "$(gofmt -s -l $(echo $GO_FILES))"
   - cd $TRAVIS_BUILD_DIR/..
   - git clone https://github.com/apache/incubator-openwhisk-utilities.git
-  - git clone https://github.com/apache/incubator-openwhisk.git
+  - git clone --depth=1 --single-branch -b scala-2-12 https://github.com/chetanmeh/incubator-openwhisk.git
   - cd incubator-openwhisk
   - ./tools/travis/setup.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
   - test -z "$(gofmt -s -l $(echo $GO_FILES))"
   - cd $TRAVIS_BUILD_DIR/..
   - git clone https://github.com/apache/incubator-openwhisk-utilities.git
-  - git clone --depth=1 --single-branch -b scala-2-12 https://github.com/chetanmeh/incubator-openwhisk.git
+  - git clone https://github.com/apache/incubator-openwhisk.git
   - cd incubator-openwhisk
   - ./tools/travis/setup.sh
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,7 @@ gradle.ext.openwhisk = [
 ]
 
 gradle.ext.scala = [
-    version: '2.11.8',
+    version: '2.12.7',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]
 


### PR DESCRIPTION
Switches Scala version to 2.12.7 as part of apache/incubator-openwhisk#3952

To validate that build passes fine this PR build against the [scala-2-12][1] branch. Following sequence of steps would happen

1. apache/incubator-openwhisk#4062 is merged
2. Change the git url in install scripts
3. Merge this PR

[1]: https://github.com/chetanmeh/incubator-openwhisk/tree/scala-2-12