### PR TITLE
golint package path update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ resolveBuildDependencies.dependsOn(goI18n)
        The get step is needed to be sure a golint binary is available to run.
  */
 task getGoLint(type: com.github.blindpirate.gogradle.Go) {
-    go 'get -u github.com/golang/lint/golint'
+    go 'get -u golang.org/x/lint/golint'
 }
 
 task goLint(type: com.github.blindpirate.gogradle.Go, dependsOn: getGoLint) {

--- a/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
@@ -269,7 +269,9 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
     val tmpwskprops = File.createTempFile("wskprops", ".tmp")
     try {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-      val apihost = s"http://${WhiskProperties.getBaseControllerAddress()}"
+      val controllerProtocol = WhiskProperties.getProperty("controller.protocol")
+      val apihost =
+        s"${controllerProtocol}://${WhiskProperties.getBaseControllerAddress()}"
       wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
       rr.stdout should not include regex("""whisk API build\s*Unknown""")

--- a/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
@@ -265,13 +265,13 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
     }
   }
 
-  it should "show api build using http apihost" in {
+  it should "show api build using explicit protocol for apihost" in {
     val tmpwskprops = File.createTempFile("wskprops", ".tmp")
     try {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       val controllerProtocol = WhiskProperties.getProperty("controller.protocol")
       val apihost =
-        s"${controllerProtocol}://${WhiskProperties.getBaseControllerAddress()}"
+        s"${controllerProtocol}://${WhiskProperties.getBaseControllerHost()}"
       wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
       rr.stdout should not include regex("""whisk API build\s*Unknown""")


### PR DESCRIPTION
fixes travis failure
```
$ go get -u github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /home/travis/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
```