### PR TITLE
Pin go version used by gogradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - os: linux
       sudo: required
       group: deprecated-2017Q3
-      go: 1.9
+      go: 1.9.3
       services: docker
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - os: linux
       sudo: required
       group: deprecated-2017Q3
-      go: 1.9.3
+      go: "1.9.3"
       services: docker
 
 env:

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ subprojects {
 golang {
     packagePath = 'github.com/apache/incubator-openwhisk-cli' as String
     buildTags = (rootProject.findProperty('goTags')?:'').split(',')
+    goVersion = '1.9.3'
 }
 
 dependencies {


### PR DESCRIPTION
In some environments where no go binary is installed, gogradle will attempt to download it. If no version is specified, the latest is used. The latest version `1.11` has sharpened the compiler so some code changes in the cli are required to support it, otherwise it won't compile, see https://github.com/apache/incubator-openwhisk-cli/issues/380.

With this change the go version is pinned to the officially supported - `1.9`