### PR TITLE
Save Code Associated with Blackbox Actions

### DIFF
--- a/commands/action.go
+++ b/commands/action.go
@@ -692,7 +692,7 @@ func saveCode(action whisk.Action, filename string) (err error) {
 	exec = *action.Exec
 	runtime = strings.Split(exec.Kind, ":")[0]
 
-	if strings.ToLower(runtime) == BLACKBOX {
+	if strings.ToLower(runtime) == BLACKBOX && exec.Code == nil && *exec.Binary == false {
 		return cannotSaveImageError()
 	} else if strings.ToLower(runtime) == SEQUENCE {
 		return cannotSaveSequenceError()

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -1086,22 +1086,18 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
     val saveName = s"save-as-$name.js"
     val badSaveName = s"bad-directory${File.separator}$saveName"
 
-    Seq(
-      (name, true, false, false),
-      (name, false, true, false),
-      (name, false, false, true)
-    ).foreach {
+    Seq((name, true, false, false), (name, false, true, false), (name, false, false, true)).foreach {
       case (actionName, save, saveAs, blackbox) =>
         assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
           blackbox match {
             case false => action.create(name, defaultAction, update = true)
-            case true => action.create(name, defaultAction, update = true, docker = Some("asdf"))
+            case true  => action.create(name, defaultAction, update = true, docker = Some("asdf"))
           }
         }
 
         val saveMsg: String = if (save) {
           wsk.action.get(name, save = Some(true)).stdout
-        } else  {
+        } else {
           wsk.action.get(name, saveAs = Some(saveName)).stdout
         }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -1091,7 +1091,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
         assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
           blackbox match {
             case false => action.create(name, defaultAction, update = true)
-            case true  => action.create(name, defaultAction, update = true, docker = Some("asdf"))
+            case true  => action.create(name, defaultAction, update = true, docker = Some("bogus"))
           }
         }
 


### PR DESCRIPTION
Currently attempting to save any blackbox action results in an error. These changes update the code saving functionality to  allow for saving of code associated with blackbox actions. 