### PR TITLE
Add dynamic column sizing to wsk activation list command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
         build(['name':'golang.org/x/sys/unix', 'version':'7f918dd405547ecb864d14a8ecbbfe205b5f930f', 'transitive':false])
         build(['name':'gopkg.in/yaml.v2', 'version':'eb3733d160e74a9c7e442f435eb3bea458e1d19f', 'transitive':false])
         build(['name':'github.com/ghodss/yaml', 'version':'0ca9ea5df5451ffdf184b4428c902747c2c11cd7', 'transitive':false])
-        build(['name':'github.com/apache/incubator-openwhisk-client-go/whisk','version':'4286a8212a74c40d8950ee76681a67e12c9bf1a0','transitive':false])
+        build(['name':'github.com/apache/incubator-openwhisk-client-go/whisk','version':'47ad3426a4e3632fd17d859303f4074ae7b959ff','transitive':false])
         build(['name':'github.com/apache/incubator-openwhisk-wskdeploy','version':'7d79fd74ca1045658196e5004f8820b67570734c','transitive':false])
         // END - Imported from Godeps
         test name:'github.com/stretchr/testify', version:'b91bfb9ebec76498946beb6af7c0230c7cc7ba6c', transitive:false //, tag: 'v1.2.0'

--- a/commands/util.go
+++ b/commands/util.go
@@ -212,7 +212,7 @@ func printList(collection interface{}, sortByName bool) {
 		for i := range collection {
 			commandToSort = append(commandToSort, collection[i])
 		}
-	case []whisk.Activation:
+	case []whisk.ActivationFilteredRow:
 		for i := range collection {
 			commandToSort = append(commandToSort, collection[i])
 		}
@@ -265,6 +265,8 @@ func makeDefaultHeader(collection interface{}) string {
 	if defaultHeader == "apifilteredrows" {
 		defaultHeader = fmt.Sprintf("%-30s %7s %20s  %s", "Action", "Verb", "API Name", "URL")
 	} else if defaultHeader == "apifilteredlists" {
+		defaultHeader = ""
+	} else if defaultHeader == "activationfilteredrows" {
 		defaultHeader = ""
 	}
 	return defaultHeader

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "6D6U+hfBxkxhDZWSHTrn8uhGod8=",
+			"checksumSHA1": "W0Cr3GbXN1qhrbg6BVwt2VH9qSQ=",
 			"path": "github.com/apache/incubator-openwhisk-client-go/whisk",
-			"revision": "4286a8212a74c40d8950ee76681a67e12c9bf1a0",
-			"revisionTime": "2019-03-04T14:44:55Z"
+			"revision": "47ad3426a4e3632fd17d859303f4074ae7b959ff",
+			"revisionTime": "2019-04-04T18:35:19Z"
 		},
 		{
 			"checksumSHA1": "4NY5lFykxXaoN+JNMxo179L79sU=",


### PR DESCRIPTION
This addresses https://github.com/apache/incubator-openwhisk-client-go/issues/119 and adds dynamic sizing behavior to the *Kind* and *Status* columns, as well as skips the column heading if there are no activation records to display.

With this change, the behavior will be:

```wsk activation list --skip 20 --limit 5```
<pre>
Datetime            Activation ID                    Kind     Start Duration   Status  Entity
2019-03-14 14:49:11 847b942103bb4b43bb942103bb7b4376 nodejs:6 warm  2ms        success guest/helloworld:0.0.1
2019-03-14 14:47:48 d5c208b0336c40328208b0336ca03222 nodejs:6 cold  33ms       success guest/helloworld:0.0.1
2019-03-14 09:04:49 d8b4fb863117413ab4fb863117513af5 nodejs:6 cold  31ms       success guest/greeting:0.0.1
2019-03-12 19:28:25 daa12f0d612f4426a12f0d612f8426c4 nodejs:6 cold  129ms      success guest/greeting:0.0.1
2019-03-12 18:20:32 daa5acdcc48947e0a5acdcc489f7e04e nodejs:6 cold  116ms      success guest/greeting:0.0.1
</pre>

And, then for next pagination we can see how the columns change dynamically (see the Status and Entity columns):

```wsk activation list --skip 25 --limit 5```
<pre>
Datetime            Activation ID                    Kind     Start Duration   Status            Entity
2019-02-28 10:08:27 3d578d89fd0f4106978d89fd0f110650 nodejs:6 cold  741ms      success           guest/kafkaFeed:0.0.2
2019-02-27 15:17:05 05b8edb3f5aa40cbb8edb3f5aaf0cbc9 nodejs:6 warm  126ms      success           guest/kafkaFeed:0.0.2
2019-02-27 15:16:16 b18da1f06f4143718da1f06f41937150 nodejs:6 warm  129ms      success           guest/kafkaFeed:0.0.2
2019-02-27 15:14:28 5d8d23b5082d4dba8d23b5082d4dba8a nodejs:6 warm  99ms       application error guest/kafkaFeed:0.0.2
2019-02-27 15:10:34 3d7e4912dc224273be4912dc227273a9 nodejs:6 cold  966ms      success           guest/kafkaFeed:0.0.2
</pre>

This PR is dependent on https://github.com/apache/incubator-openwhisk-client-go/pull/120, and when that has been merged into client-go, the `build.gradle` file needs to be updated to the commit hash of that PR.

- [x] I have signed a CLA