### PR TITLE
"wsk property get" should return raw output when provided with specific property. 

### DIFF
--- a/commands/flags.go
+++ b/commands/flags.go
@@ -84,6 +84,7 @@ type FlagsStruct struct {
 		apihostSet    string
 		apiversionSet string
 		namespaceSet  string
+		output        string
 	}
 
 	action ActionFlags

--- a/commands/property.go
+++ b/commands/property.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"github.com/fatih/color"
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 
 	"github.com/apache/incubator-openwhisk-cli/wski18n"
@@ -295,56 +295,67 @@ var propertyGetCmd = &cobra.Command{
 			Flags.property.apihost || Flags.property.apibuildno) {
 			Flags.property.all = true
 		}
-
-		if Flags.property.all || Flags.property.cert {
+		if Flags.property.all {
 			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("client cert"), boldString(Properties.Cert))
-		}
-
-		if Flags.property.all || Flags.property.key {
 			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("Client key"), boldString(Properties.Key))
-		}
-
-		if Flags.property.all || Flags.property.auth {
 			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk auth"), boldString(Properties.Auth))
-		}
-
-		if Flags.property.all || Flags.property.apihost {
 			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk API host"), boldString(Properties.APIHost))
-		}
-
-		if Flags.property.all || Flags.property.apiversion {
 			fmt.Fprintf(color.Output, "%s\t%s\n", wski18n.T("whisk API version"), boldString(Properties.APIVersion))
-		}
-
-		if Flags.property.all || Flags.property.namespace {
 			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk namespace"), boldString(Properties.Namespace))
-		}
-
-		if Flags.property.all || Flags.property.cliversion {
 			fmt.Fprintf(color.Output, "%s\t%s\n", wski18n.T("whisk CLI version"), boldString(Properties.CLIVersion))
 		}
 
-		if Flags.property.all || Flags.property.apibuild || Flags.property.apibuildno {
-			info, _, err := Client.Info.Get()
-			if err != nil {
-				whisk.Debug(whisk.DbgError, "Client.Info.Get() failed: %s\n", err)
-				info = &whisk.Info{}
-				info.Build = wski18n.T("Unknown")
-				info.BuildNo = wski18n.T("Unknown")
-			}
-			if Flags.property.all || Flags.property.apibuild {
-				fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk API build"), boldString(info.Build))
-			}
-			if Flags.property.all || Flags.property.apibuildno {
-				fmt.Fprintf(color.Output, "%s\t%s\n", wski18n.T("whisk API build number"), boldString(info.BuildNo))
-			}
-			if err != nil {
-				errStr := fmt.Sprintf(
-					wski18n.T("Unable to obtain API build information: {{.err}}",
-						map[string]interface{}{"err": err}))
-				werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXIT_CODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-				return werr
-			}
+		if Flags.property.cert {
+			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.Cert))
+		}
+
+		if Flags.property.key {
+			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.Key))
+		}
+
+		if Flags.property.auth {
+			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.Auth))
+		}
+
+		if Flags.property.apihost {
+			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.APIHost))
+		}
+
+		if Flags.property.apiversion {
+			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.APIVersion))
+		}
+
+		if Flags.property.namespace {
+			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.Namespace))
+		}
+
+		if Flags.property.cliversion {
+			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.CLIVersion))
+		}
+
+		info, _, err := Client.Info.Get()
+		if err != nil {
+			whisk.Debug(whisk.DbgError, "Client.Info.Get() failed: %s\n", err)
+			info = &whisk.Info{}
+			info.Build = wski18n.T("Unknown")
+			info.BuildNo = wski18n.T("Unknown")
+		}
+		if Flags.property.all {
+			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk API build"), boldString(info.Build))
+			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk API build number"), boldString(info.BuildNo))
+		}
+		if Flags.property.apibuild {
+			fmt.Fprintf(color.Output, "%s\n", boldString(info.Build))
+		}
+		if Flags.property.apibuildno {
+			fmt.Fprintf(color.Output, "%s\n", boldString(info.BuildNo))
+		}
+		if err != nil {
+			errStr := fmt.Sprintf(
+				wski18n.T("Unable to obtain API build information: {{.err}}",
+					map[string]interface{}{"err": err}))
+			werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXIT_CODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+			return werr
 		}
 
 		return nil

--- a/commands/property.go
+++ b/commands/property.go
@@ -340,21 +340,25 @@ var propertyGetCmd = &cobra.Command{
 			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T(propDisplayNamespace), boldString(Properties.Namespace))
 			fmt.Fprintf(color.Output, "%s\t%s\n", wski18n.T(propDisplayCLIVersion), boldString(Properties.CLIVersion))
 		} else {
-			property := Flags.property
-			switch {
-			case property.cert:
+			if Flags.property.cert {
 				printProperty(Properties.Cert, propDisplayCert, outputFormat)
-			case property.key:
+			}
+			if Flags.property.key {
 				printProperty(Properties.Key, propDisplayKey, outputFormat)
-			case property.cliversion:
-				printProperty(Properties.CLIVersion, propDisplayCLIVersion, outputFormat)
-			case property.apihost:
+			}
+			if Flags.property.cliversion {
+				printProperty(Properties.CLIVersion, propDisplayCLIVersion, outputFormat, "%s\t%s\n")
+			}
+			if Flags.property.apihost {
 				printProperty(Properties.APIHost, propDisplayAPIHost, outputFormat)
-			case property.auth:
+			}
+			if Flags.property.auth {
 				printProperty(Properties.Auth, propDisplayAuth, outputFormat)
-			case property.apiversion:
-				printProperty(Properties.APIVersion, propDisplayAPIVersion, outputFormat)
-			case property.namespace:
+			}
+			if Flags.property.apiversion {
+				printProperty(Properties.APIVersion, propDisplayAPIVersion, outputFormat, "%s\t%s\n")
+			}
+			if Flags.property.namespace {
 				printProperty(Properties.Namespace, propDisplayNamespace, outputFormat)
 			}
 		}
@@ -370,10 +374,12 @@ var propertyGetCmd = &cobra.Command{
 			if Flags.property.all {
 				fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T(propDisplayAPIBuild), boldString(info.Build))
 				fmt.Fprintf(color.Output, "%s\t%s\n", wski18n.T(propDisplayAPIBuildNo), boldString(info.BuildNo))
-			} else if Flags.property.apibuild {
+			}
+			if Flags.property.apibuild && !Flags.property.all {
 				printProperty(info.Build, propDisplayAPIBuild, outputFormat)
-			} else if Flags.property.apibuildno {
-				printProperty(info.Build, propDisplayAPIBuildNo, outputFormat)
+			}
+			if Flags.property.apibuildno && !Flags.property.all {
+				printProperty(info.BuildNo, propDisplayAPIBuildNo, outputFormat, "%s\t%s\n")
 			}
 			if err != nil {
 				errStr := fmt.Sprintf(
@@ -596,16 +602,20 @@ func parseConfigFlags(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printProperty(propertyName string, defaultKey string, format string) {
-	switch format {
+func printProperty(propertyName string, displayText string, formatType string, format ...string) {
+	switch formatType {
 	case "std":
-		fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T(defaultKey), boldString(propertyName))
+		if len(format) > 0 {
+			fmt.Fprintf(color.Output, format[0], wski18n.T(displayText), boldString(propertyName))
+			break
+		}
+		fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T(displayText), boldString(propertyName))
 		break
 	case "raw":
 		fmt.Fprintf(color.Output, "%s\n", boldString(propertyName))
 		break
 	default:
 		// In case of any other type for now print in std format.
-		fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T(defaultKey), boldString(propertyName))
+		fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T(displayText), boldString(propertyName))
 	}
 }

--- a/commands/property.go
+++ b/commands/property.go
@@ -305,59 +305,60 @@ var propertyGetCmd = &cobra.Command{
 			fmt.Fprintf(color.Output, "%s\t%s\n", wski18n.T("whisk CLI version"), boldString(Properties.CLIVersion))
 		}
 
-		if Flags.property.cert {
+		if Flags.property.cert && !Flags.property.all {
 			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.Cert))
 		}
 
-		if Flags.property.key {
+		if Flags.property.key && !Flags.property.all {
 			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.Key))
 		}
 
-		if Flags.property.auth {
+		if Flags.property.auth && !Flags.property.all {
 			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.Auth))
 		}
 
-		if Flags.property.apihost {
+		if Flags.property.apihost && !Flags.property.all {
 			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.APIHost))
 		}
 
-		if Flags.property.apiversion {
+		if Flags.property.apiversion && !Flags.property.all {
 			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.APIVersion))
 		}
 
-		if Flags.property.namespace {
+		if Flags.property.namespace && !Flags.property.all {
 			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.Namespace))
 		}
 
-		if Flags.property.cliversion {
+		if Flags.property.cliversion && !Flags.property.all {
 			fmt.Fprintf(color.Output, "%s\n", boldString(Properties.CLIVersion))
 		}
 
-		info, _, err := Client.Info.Get()
-		if err != nil {
-			whisk.Debug(whisk.DbgError, "Client.Info.Get() failed: %s\n", err)
-			info = &whisk.Info{}
-			info.Build = wski18n.T("Unknown")
-			info.BuildNo = wski18n.T("Unknown")
+		if Flags.property.all || Flags.property.apibuild || Flags.property.apibuildno {
+			info, _, err := Client.Info.Get()
+			if err != nil {
+				whisk.Debug(whisk.DbgError, "Client.Info.Get() failed: %s\n", err)
+				info = &whisk.Info{}
+				info.Build = wski18n.T("Unknown")
+				info.BuildNo = wski18n.T("Unknown")
+			}
+			if Flags.property.all {
+				fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk API build"), boldString(info.Build))
+				fmt.Fprintf(color.Output, "%s\t%s\n", wski18n.T("whisk API build number"), boldString(info.BuildNo))
+			}
+			if Flags.property.apibuild {
+				fmt.Fprintf(color.Output, "%s\n", boldString(info.Build))
+			}
+			if Flags.property.apibuildno {
+				fmt.Fprintf(color.Output, "%s\n", boldString(info.BuildNo))
+			}
+			if err != nil {
+				errStr := fmt.Sprintf(
+					wski18n.T("Unable to obtain API build information: {{.err}}",
+						map[string]interface{}{"err": err}))
+				werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXIT_CODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+				return werr
+			}
 		}
-		if Flags.property.all {
-			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk API build"), boldString(info.Build))
-			fmt.Fprintf(color.Output, "%s\t\t%s\n", wski18n.T("whisk API build number"), boldString(info.BuildNo))
-		}
-		if Flags.property.apibuild {
-			fmt.Fprintf(color.Output, "%s\n", boldString(info.Build))
-		}
-		if Flags.property.apibuildno {
-			fmt.Fprintf(color.Output, "%s\n", boldString(info.BuildNo))
-		}
-		if err != nil {
-			errStr := fmt.Sprintf(
-				wski18n.T("Unable to obtain API build information: {{.err}}",
-					map[string]interface{}{"err": err}))
-			werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXIT_CODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-			return werr
-		}
-
 		return nil
 	},
 }

--- a/tests/src/integration/command_test.go
+++ b/tests/src/integration/command_test.go
@@ -20,10 +20,11 @@
 package tests
 
 import (
-	"github.com/apache/incubator-openwhisk-cli/tests/src/integration/common"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/apache/incubator-openwhisk-cli/tests/src/integration/common"
+	"github.com/stretchr/testify/assert"
 )
 
 var wsk *common.Wsk = common.NewWsk()
@@ -65,17 +66,17 @@ func TestShowCLIBuildVersion(t *testing.T) {
 	stdout, err := wsk.RunCommand("property", "get", "--cliversion")
 	assert.Equal(t, nil, err, "The command property get --cliversion failed to run.")
 	output := common.RemoveRedundentSpaces(string(stdout))
-	assert.NotContains(t, output, "whisk CLI version not set",
-		"The output of the command property get --cliversion contains \"whisk CLI version not set\".")
-	assert.Contains(t, output, "whisk CLI version",
-		"The output of the command property get --cliversion does not contain \"whisk CLI version\".")
+	assert.NotContains(t, output, "not set",
+		"The output of the command property get --cliversion contains \"not set\".")
+	assert.Contains(t, output, "20",
+		"The output of the command property get --cliversion does not contain \"20\".")
 }
 
 func TestShowAPIVersion(t *testing.T) {
 	stdout, err := wsk.RunCommand("property", "get", "--apiversion")
 	assert.Equal(t, nil, err, "The command property get --apiversion failed to run.")
-	assert.Contains(t, string(stdout), "whisk API version",
-		"The output of the command property get --apiversion does not contain \"whisk API version\".")
+	assert.Contains(t, string(stdout), "v1",
+		"The output of the command property get --apiversion does not contain \"v1\".")
 }
 
 // Test case to verify the default namespace _.
@@ -88,8 +89,8 @@ func TestDefaultNamespace(t *testing.T) {
 
 	stdout, err := wsk.RunCommand("property", "get", "-i", "--namespace")
 	assert.Equal(t, nil, err, "The command property get -i --namespace failed to run.")
-	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "whisk namespace _",
-		"The output of the command does not contain \"whisk namespace _\".")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "_",
+		"The output of the command does not contain \"_\".")
 	common.DeleteFile(tmpProp)
 }
 
@@ -114,18 +115,18 @@ func TestValidateDefaultProperties(t *testing.T) {
 
 	stdout, err = wsk.RunCommand("property", "get", "--auth")
 	assert.Equal(t, nil, err, "The command property get --auth failed to run.")
-	assert.Equal(t, "whisk auth", common.RemoveRedundentSpaces(string(stdout)),
-		"The output of the command does not equal to \"whisk auth\".")
+	assert.Equal(t, "", common.RemoveRedundentSpaces(string(stdout)),
+		"The output of the command does not equal to \"\".")
 
 	stdout, err = wsk.RunCommand("property", "get", "--apihost")
 	assert.Equal(t, nil, err, "The command property get --apihost failed to run.")
-	assert.Equal(t, "whisk API host", common.RemoveRedundentSpaces(string(stdout)),
-		"The output of the command does not equal to \"whisk API host\".")
+	assert.Equal(t, "", common.RemoveRedundentSpaces(string(stdout)),
+		"The output of the command does not equal to \"\".")
 
 	stdout, err = wsk.RunCommand("property", "get", "--namespace")
 	assert.Equal(t, nil, err, "The command property get --namespace failed to run.")
-	assert.Equal(t, "whisk namespace _", common.RemoveRedundentSpaces(string(stdout)),
-		"The output of the command does not equal to \"whisk namespace _\".")
+	assert.Equal(t, "_", common.RemoveRedundentSpaces(string(stdout)),
+		"The output of the command does not equal to \"_\".")
 
 	common.DeleteFile(tmpProp)
 }

--- a/tests/src/integration/command_test.go
+++ b/tests/src/integration/command_test.go
@@ -66,17 +66,17 @@ func TestShowCLIBuildVersion(t *testing.T) {
 	stdout, err := wsk.RunCommand("property", "get", "--cliversion")
 	assert.Equal(t, nil, err, "The command property get --cliversion failed to run.")
 	output := common.RemoveRedundentSpaces(string(stdout))
-	assert.NotContains(t, output, "not set",
-		"The output of the command property get --cliversion contains \"not set\".")
-	assert.Contains(t, output, "20",
-		"The output of the command property get --cliversion does not contain \"20\".")
+	assert.NotContains(t, output, common.PropDisplayCLIVersion+" not set",
+		"The output of the command property get --cliversion contains "+common.PropDisplayCLIVersion+" not set")
+	assert.Contains(t, output, common.PropDisplayCLIVersion,
+		"The output of the command property get --cliversion does not contain "+common.PropDisplayCLIVersion)
 }
 
 func TestShowAPIVersion(t *testing.T) {
 	stdout, err := wsk.RunCommand("property", "get", "--apiversion")
 	assert.Equal(t, nil, err, "The command property get --apiversion failed to run.")
-	assert.Contains(t, string(stdout), "v1",
-		"The output of the command property get --apiversion does not contain \"v1\".")
+	assert.Contains(t, string(stdout), common.PropDisplayAPIVersion,
+		"The output of the command property get --apiversion does not contain "+common.PropDisplayCLIVersion)
 }
 
 // Test case to verify the default namespace _.
@@ -89,8 +89,8 @@ func TestDefaultNamespace(t *testing.T) {
 
 	stdout, err := wsk.RunCommand("property", "get", "-i", "--namespace")
 	assert.Equal(t, nil, err, "The command property get -i --namespace failed to run.")
-	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "_",
-		"The output of the command does not contain \"_\".")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), common.PropDisplayNamespace+" _",
+		"The output of the command does not contain "+common.PropDisplayCLIVersion+" _")
 	common.DeleteFile(tmpProp)
 }
 
@@ -115,18 +115,18 @@ func TestValidateDefaultProperties(t *testing.T) {
 
 	stdout, err = wsk.RunCommand("property", "get", "--auth")
 	assert.Equal(t, nil, err, "The command property get --auth failed to run.")
-	assert.Equal(t, "", common.RemoveRedundentSpaces(string(stdout)),
-		"The output of the command does not equal to \"\".")
+	assert.Equal(t, common.PropDisplayAuth, common.RemoveRedundentSpaces(string(stdout)),
+		"The output of the command does not equal to "+common.PropDisplayAuth)
 
 	stdout, err = wsk.RunCommand("property", "get", "--apihost")
 	assert.Equal(t, nil, err, "The command property get --apihost failed to run.")
-	assert.Equal(t, "", common.RemoveRedundentSpaces(string(stdout)),
-		"The output of the command does not equal to \"\".")
+	assert.Equal(t, common.PropDisplayAPIHost, common.RemoveRedundentSpaces(string(stdout)),
+		"The output of the command does not equal to "+common.PropDisplayAPIHost)
 
 	stdout, err = wsk.RunCommand("property", "get", "--namespace")
 	assert.Equal(t, nil, err, "The command property get --namespace failed to run.")
-	assert.Equal(t, "_", common.RemoveRedundentSpaces(string(stdout)),
-		"The output of the command does not equal to \"_\".")
+	assert.Equal(t, common.PropDisplayNamespace+" _", common.RemoveRedundentSpaces(string(stdout)),
+		"The output of the command does not equal to "+common.PropDisplayNamespace+" _")
 
 	common.DeleteFile(tmpProp)
 }

--- a/tests/src/integration/common/utils.go
+++ b/tests/src/integration/common/utils.go
@@ -26,6 +26,18 @@ import (
 	"unicode"
 )
 
+const (
+	PropDisplayCert       = "client cert"
+	PropDisplayKey        = "Client key"
+	PropDisplayAuth       = "whisk auth"
+	PropDisplayAPIHost    = "whisk API host"
+	PropDisplayAPIVersion = "whisk API version"
+	PropDisplayNamespace  = "whisk namespace"
+	PropDisplayCLIVersion = "whisk CLI version"
+	PropDisplayAPIBuild   = "whisk API build"
+	PropDisplayAPIBuildNo = "whisk API build number"
+)
+
 func checkError(err error) {
 	if err != nil {
 		fmt.Println(err.Error())

--- a/tests/src/integration/integration_test.go
+++ b/tests/src/integration/integration_test.go
@@ -21,11 +21,12 @@ package tests
 
 import (
 	"fmt"
-	"github.com/apache/incubator-openwhisk-cli/tests/src/integration/common"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/apache/incubator-openwhisk-cli/tests/src/integration/common"
+	"github.com/stretchr/testify/assert"
 )
 
 var invalidArgs []common.InvalidArg
@@ -370,12 +371,12 @@ func TestShowAPIBuildVersion(t *testing.T) {
 	stdout, err = wsk.RunCommand("property", "get", "-i", "--apibuild")
 	assert.Equal(t, nil, err, "The command property get -i --apibuild failed to run.")
 	println(common.RemoveRedundentSpaces(string(stdout)))
-	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "whisk API build Unknown",
-		"The output of the command property get --apibuild does not contain \"whisk API build Unknown\".")
+	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "Unknown",
+		"The output of the command property get --apibuild does not contain \"Unknown\".")
 	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "Unable to obtain API build information",
 		"The output of the command property get --apibuild does not contain \"Unable to obtain API build information\".")
-	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "whisk API build 20",
-		"The output of the command property get --apibuild does not contain \"whisk API build 20\".")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "20",
+		"The output of the command property get --apibuild does not contain \"20\".")
 	common.DeleteFile(tmpProp)
 }
 
@@ -390,8 +391,8 @@ func TestFailShowAPIBuildVersion(t *testing.T) {
 	assert.Equal(t, nil, err, "The command property set --apihost failed to run.")
 	stdout, err := wsk.RunCommand("property", "get", "-i", "--apibuild")
 	assert.NotEqual(t, nil, err, "The command property get -i --apibuild does not raise any error.")
-	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "whisk API build Unknown",
-		"The output of the command property get --apibuild does not contain \"whisk API build Unknown\".")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "Unknown",
+		"The output of the command property get --apibuild does not contain \"Unknown\".")
 	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "Unable to obtain API build information",
 		"The output of the command property get --apibuild does not contain \"Unable to obtain API build information\".")
 }
@@ -409,12 +410,12 @@ func TestShowAPIBuildVersionHTTP(t *testing.T) {
 	stdout, err = wsk.RunCommand("property", "get", "-i", "--apibuild")
 	println(common.RemoveRedundentSpaces(string(stdout)))
 	//assert.Equal(t, nil, err, "The command property get -i --apibuild failed to run.")
-	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "whisk API build Unknown",
-		"The output of the command property get --apibuild does not contain \"whisk API build Unknown\".")
+	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "Unknown",
+		"The output of the command property get --apibuild does not contain \"Unknown\".")
 	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "Unable to obtain API build information",
 		"The output of the command property get --apibuild does not contain \"Unable to obtain API build information\".")
-	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "whisk API build 20",
-		"The output of the command property get --apibuild does not contain \"whisk API build 20\".")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "20",
+		"The output of the command property get --apibuild does not contain \"20\".")
 	common.DeleteFile(tmpProp)
 }
 

--- a/tests/src/integration/integration_test.go
+++ b/tests/src/integration/integration_test.go
@@ -371,12 +371,12 @@ func TestShowAPIBuildVersion(t *testing.T) {
 	stdout, err = wsk.RunCommand("property", "get", "-i", "--apibuild")
 	assert.Equal(t, nil, err, "The command property get -i --apibuild failed to run.")
 	println(common.RemoveRedundentSpaces(string(stdout)))
-	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "Unknown",
-		"The output of the command property get --apibuild does not contain \"Unknown\".")
+	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), common.PropDisplayAPIBuild+" Unknown",
+		"The output of the command property get --apibuild does not contain "+common.PropDisplayAPIBuild+" Unknown")
 	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "Unable to obtain API build information",
 		"The output of the command property get --apibuild does not contain \"Unable to obtain API build information\".")
-	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "20",
-		"The output of the command property get --apibuild does not contain \"20\".")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), common.PropDisplayAPIBuild+" 20",
+		"The output of the command property get --apibuild does not contain"+common.PropDisplayAPIBuild+" 20")
 	common.DeleteFile(tmpProp)
 }
 
@@ -391,8 +391,8 @@ func TestFailShowAPIBuildVersion(t *testing.T) {
 	assert.Equal(t, nil, err, "The command property set --apihost failed to run.")
 	stdout, err := wsk.RunCommand("property", "get", "-i", "--apibuild")
 	assert.NotEqual(t, nil, err, "The command property get -i --apibuild does not raise any error.")
-	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "Unknown",
-		"The output of the command property get --apibuild does not contain \"Unknown\".")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), common.PropDisplayAPIBuild+" Unknown",
+		"The output of the command property get --apibuild does not contain"+common.PropDisplayAPIBuild+" Unknown")
 	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "Unable to obtain API build information",
 		"The output of the command property get --apibuild does not contain \"Unable to obtain API build information\".")
 }
@@ -410,12 +410,12 @@ func TestShowAPIBuildVersionHTTP(t *testing.T) {
 	stdout, err = wsk.RunCommand("property", "get", "-i", "--apibuild")
 	println(common.RemoveRedundentSpaces(string(stdout)))
 	//assert.Equal(t, nil, err, "The command property get -i --apibuild failed to run.")
-	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "Unknown",
-		"The output of the command property get --apibuild does not contain \"Unknown\".")
+	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), common.PropDisplayAPIBuild+" Unknown",
+		"The output of the command property get --apibuild does not contain "+common.PropDisplayAPIBuild+" Unknown")
 	assert.NotContains(t, common.RemoveRedundentSpaces(string(stdout)), "Unable to obtain API build information",
 		"The output of the command property get --apibuild does not contain \"Unable to obtain API build information\".")
-	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "20",
-		"The output of the command property get --apibuild does not contain \"20\".")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), common.PropDisplayAPIBuild+" 20",
+		"The output of the command property get --apibuild does not contain "+common.PropDisplayAPIBuild+" 20")
 	common.DeleteFile(tmpProp)
 }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -84,12 +84,12 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
 
   it should "show cli build version" in {
     val stdout = wsk.cli(Seq("property", "get", "--cliversion")).stdout
-    stdout should include regex ("""(?i)whisk CLI version\s+201.*""")
+    stdout should startsWith regex ("201.*")
   }
 
   it should "show api version" in {
     val stdout = wsk.cli(Seq("property", "get", "--apiversion")).stdout
-    stdout should include regex ("""(?i)whisk API version\s+v1""")
+    stdout should startsWith ("v1")
   }
 
   it should "reject bad command" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -89,7 +89,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
 
   it should "show api version" in {
     val stdout = wsk.cli(Seq("property", "get", "--apiversion")).stdout
-    stdout should startsWith ("v1")
+    stdout should startsWith("v1")
   }
 
   it should "reject bad command" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -84,12 +84,12 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
 
   it should "show cli build version" in {
     val stdout = wsk.cli(Seq("property", "get", "--cliversion")).stdout
-    stdout should startWith regex ("20.*")
+    stdout should include regex ("""(?i)whisk CLI version\s+20.*""")
   }
 
   it should "show api version" in {
     val stdout = wsk.cli(Seq("property", "get", "--apiversion")).stdout
-    stdout should startWith("v1")
+    stdout should include regex ("""(?i)whisk API version\s+v1""")
   }
 
   it should "reject bad command" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -84,12 +84,12 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
 
   it should "show cli build version" in {
     val stdout = wsk.cli(Seq("property", "get", "--cliversion")).stdout
-    stdout should startsWith regex ("201.*")
+    stdout should startWith regex ("20.*")
   }
 
   it should "show api version" in {
     val stdout = wsk.cli(Seq("property", "get", "--apiversion")).stdout
-    stdout should startsWith("v1")
+    stdout should startWith("v1")
   }
 
   it should "reject bad command" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskConfigTests.scala
@@ -88,7 +88,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
         .stdout should include regex ("""(?i)\\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--namespace"), env = env)
-        .stdout should include ("_") // default = _
+        .stdout should include("_") // default = _
     } finally {
       tmpwskprops.delete()
     }
@@ -247,7 +247,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       writer.close()
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       val stdout = wsk.cli(Seq("property", "get", "-i", "--namespace"), env = env).stdout
-      stdout should startWith ("_")
+      stdout should startWith("_")
     } finally {
       tmpwskprops.delete()
     }
@@ -274,9 +274,9 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
         s"${controllerProtocol}://${WhiskProperties.getBaseControllerHost()}"
       wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
-      rr.stdout should not include regex ("Unknown")
-      rr.stderr should not include regex ("Unable to obtain API build information")
-      rr.stdout should startWith regex("20.*")
+      rr.stdout should not include regex("Unknown")
+      rr.stderr should not include regex("Unable to obtain API build information")
+      rr.stdout should startWith regex ("20.*")
     } finally {
       tmpwskprops.delete()
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskConfigTests.scala
@@ -259,7 +259,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       wsk.cli(Seq("property", "set", "-i") ++ wskprops.overrides, env = env)
       val stdout = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env).stdout
-      stdout should startWith regex ("201.*")
+      stdout should startWith regex ("20.*")
     } finally {
       tmpwskprops.delete()
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskConfigTests.scala
@@ -47,7 +47,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       wsk.cli(Seq("property", "set", "-i", "--apihost", "xxxx.yyyy"), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env, expectedExitCode = NETWORK_ERROR_EXIT)
-      rr.stdout should include regex ("Unknown")
+      rr.stdout should include regex ("""whisk API build\s*Unknown""")
       rr.stderr should include regex ("Unable to obtain API build information")
     } finally {
       tmpwskprops.delete()
@@ -76,19 +76,19 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
 
       wsk
         .cli(Seq("property", "get", "--auth"), env = env)
-        .stdout should include regex ("""(?i)\\s*$""") // default = empty string
+        .stdout should include regex ("""(?i)whisk auth\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--cert"), env = env)
-        .stdout should include regex ("""(?i)\\s*$""") // default = empty string
+        .stdout should include regex ("""(?i)client cert\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--key"), env = env)
-        .stdout should include regex ("""(?i)\\s*$""") // default = empty string
+        .stdout should include regex ("""(?i)client key\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--apihost"), env = env)
-        .stdout should include regex ("""(?i)\\s*$""") // default = empty string
+        .stdout should include regex ("""(?i)whisk API host\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--namespace"), env = env)
-        .stdout should include("_") // default = _
+        .stdout should include regex ("""(?i)whisk namespace\s*_$""") // default = _
     } finally {
       tmpwskprops.delete()
     }
@@ -126,8 +126,8 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "--apibuildno", "-i"), env = env)
       rr.stderr should not include ("https:///api/v1: http: no Host in request URL")
       rr.stdout should not include regex("Cannot determine API build")
-      rr.stdout should include regex ("""(?i)\s+201.*""")
-      rr.stdout should include regex ("""(?i)v1\s+.*""")
+      rr.stdout should include regex ("""(?i)whisk API build\s+20.*""")
+      rr.stdout should include regex ("""(?i)whisk API build number\s+.*""")
     } finally {
       tmpProps.delete()
     }
@@ -141,7 +141,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       writer.close()
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       val stdout = wsk.cli(Seq("property", "get", "-i", "--apihost"), env = env).stdout
-      stdout should include regex ("\\s+http://localhost:10001$")
+      stdout should include regex ("whisk API host\\s+http://localhost:10001$")
     } finally {
       tmpwskprops.delete()
     }
@@ -247,7 +247,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       writer.close()
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       val stdout = wsk.cli(Seq("property", "get", "-i", "--namespace"), env = env).stdout
-      stdout should startWith("_")
+      stdout should include regex ("whisk namespace\\s+_")
     } finally {
       tmpwskprops.delete()
     }
@@ -259,7 +259,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       wsk.cli(Seq("property", "set", "-i") ++ wskprops.overrides, env = env)
       val stdout = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env).stdout
-      stdout should startWith regex ("20.*")
+      stdout should include regex ("""(?i)whisk API build\s+20.*""")
     } finally {
       tmpwskprops.delete()
     }
@@ -274,9 +274,9 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
         s"${controllerProtocol}://${WhiskProperties.getBaseControllerHost()}"
       wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
-      rr.stdout should not include regex("Unknown")
+      rr.stdout should not include regex("""whisk API build\s*Unknown""")
       rr.stderr should not include regex("Unable to obtain API build information")
-      rr.stdout should startWith regex ("20.*")
+      rr.stdout should include regex ("""(?i)whisk API build\s+201.*""")
     } finally {
       tmpwskprops.delete()
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskConfigTests.scala
@@ -47,7 +47,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       wsk.cli(Seq("property", "set", "-i", "--apihost", "xxxx.yyyy"), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env, expectedExitCode = NETWORK_ERROR_EXIT)
-      rr.stdout should include regex ("""whisk API build\s*Unknown""")
+      rr.stdout should include regex ("Unknown")
       rr.stderr should include regex ("Unable to obtain API build information")
     } finally {
       tmpwskprops.delete()
@@ -76,19 +76,19 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
 
       wsk
         .cli(Seq("property", "get", "--auth"), env = env)
-        .stdout should include regex ("""(?i)whisk auth\s*$""") // default = empty string
+        .stdout should include regex ("""(?i)\\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--cert"), env = env)
-        .stdout should include regex ("""(?i)client cert\s*$""") // default = empty string
+        .stdout should include regex ("""(?i)\\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--key"), env = env)
-        .stdout should include regex ("""(?i)client key\s*$""") // default = empty string
+        .stdout should include regex ("""(?i)\\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--apihost"), env = env)
-        .stdout should include regex ("""(?i)whisk API host\s*$""") // default = empty string
+        .stdout should include regex ("""(?i)\\s*$""") // default = empty string
       wsk
         .cli(Seq("property", "get", "--namespace"), env = env)
-        .stdout should include regex ("""(?i)whisk namespace\s*_$""") // default = _
+        .stdout should include ("_") // default = _
     } finally {
       tmpwskprops.delete()
     }
@@ -126,8 +126,8 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "--apibuildno", "-i"), env = env)
       rr.stderr should not include ("https:///api/v1: http: no Host in request URL")
       rr.stdout should not include regex("Cannot determine API build")
-      rr.stdout should include regex ("""(?i)whisk API build\s+201.*""")
-      rr.stdout should include regex ("""(?i)whisk API build number\s+.*""")
+      rr.stdout should include regex ("""(?i)\s+201.*""")
+      rr.stdout should include regex ("""(?i)v1\s+.*""")
     } finally {
       tmpProps.delete()
     }
@@ -141,7 +141,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       writer.close()
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       val stdout = wsk.cli(Seq("property", "get", "-i", "--apihost"), env = env).stdout
-      stdout should include regex ("whisk API host\\s+http://localhost:10001$")
+      stdout should include regex ("\\s+http://localhost:10001$")
     } finally {
       tmpwskprops.delete()
     }
@@ -247,7 +247,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       writer.close()
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       val stdout = wsk.cli(Seq("property", "get", "-i", "--namespace"), env = env).stdout
-      stdout should include regex ("whisk namespace\\s+_")
+      stdout should startWith ("_")
     } finally {
       tmpwskprops.delete()
     }
@@ -259,7 +259,7 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
       val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
       wsk.cli(Seq("property", "set", "-i") ++ wskprops.overrides, env = env)
       val stdout = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env).stdout
-      stdout should include regex ("""(?i)whisk API build\s+201.*""")
+      stdout should startWith regex ("201.*")
     } finally {
       tmpwskprops.delete()
     }
@@ -274,9 +274,9 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
         s"${controllerProtocol}://${WhiskProperties.getBaseControllerHost()}"
       wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
       val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
-      rr.stdout should not include regex("""whisk API build\s*Unknown""")
-      rr.stderr should not include regex("Unable to obtain API build information")
-      rr.stdout should include regex ("""(?i)whisk API build\s+201.*""")
+      rr.stdout should not include regex ("Unknown")
+      rr.stderr should not include regex ("Unable to obtain API build information")
+      rr.stdout should startWith regex("20.*")
     } finally {
       tmpwskprops.delete()
     }


### PR DESCRIPTION
This PR attempts to address issues explained in #407.  

With this PR, wsk CLI will provide a raw output when a specific property is provided in "wsk property get" command.

**"wsk property get"**
```
Neerajs-MacBook-Pro:incubator-openwhisk-cli mangal$ ./wsk property get
client cert
Client key
whisk auth		2eafce54-d08e-4128-a109-#####
whisk API host		https://wsk-edge#####.com
whisk API version	v1
whisk namespace		mangal
whisk CLI version	not set
whisk API build		2018-01-29T18:32:59Z
whisk API build number	latest
Neerajs-MacBook-Pro:incubator-openwhisk-cli mangal$
```

```
wsk property get --namespace
mangal

# There is no need to parsing the output now. 

export NAMESPACE=`wsk property get --namespace`
echo $NAMESPACE
mangal
```

```
wsk property get --apihost
https://wsk-edge.#####.com
```

```
wsk property get --auth
2eafce54-d08e-4128-a109-####
```

If Option "--all" is present with other options then --all takes precedence. 

```
Neerajs-MacBook-Pro:incubator-openwhisk-cli mangal$ ./wsk property get --namespace --all
client cert
Client key
whisk auth		2eafce54-d08e-4128-a109-######
whisk API host		https://wsk-edge.#####.com
whisk API version	v1
whisk namespace		mangal
whisk CLI version	not set
whisk API build		2018-01-29T18:32:59Z
whisk API build number	latest
Neerajs-MacBook-Pro:incubator-openwhisk-cli mangal$
```

