### PR TITLE
remove namespace property from wskprops

### DIFF
--- a/commands/action.go
+++ b/commands/action.go
@@ -939,7 +939,7 @@ func nonNestedError(errorMessage string) error {
 }
 
 func actionParseError(cmd *cobra.Command, args []string, err error) error {
-	whisk.Debug(whisk.DbgError, "parseAction(%s, %s) error: %s\n", cmd, args, err)
+	whisk.Debug(whisk.DbgError, "parseAction(%s, %s) error: %s\n", cmd.Name(), args, err)
 
 	errMsg := wski18n.T(
 		"Invalid argument(s). {{.required}}",
@@ -1028,7 +1028,7 @@ func actionGetError(entityName string, fetchCode bool, err error) error {
 func handleInvocationError(err error, entityName string) error {
 	whisk.Debug(
 		whisk.DbgError,
-		"Client.Actions.Invoke(%s, %t) error: %s\n",
+		"Client.Actions.Invoke(%s) error: %s\n",
 		entityName,
 		err)
 

--- a/commands/api.go
+++ b/commands/api.go
@@ -205,7 +205,7 @@ var apiCreateCmd = &cobra.Command{
 			}
 			api, qname, err = parseApi(cmd, args)
 			if err != nil {
-				whisk.Debug(whisk.DbgError, "parseApi(%s, %s) error: %s\n", cmd, args, err)
+				whisk.Debug(whisk.DbgError, "parseApi(%s, %s) error: %s\n", cmd.Name(), args, err)
 				errMsg := wski18n.T("Unable to parse api command arguments: {{.err}}",
 					map[string]interface{}{"err": err})
 				whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXIT_CODE_ERR_GENERAL,
@@ -653,7 +653,7 @@ func genFilteredList(resultApi *whisk.RetApi, apiPath string, apiVerb string) []
 							actionName = "/" + opv.XOpenWhisk.Namespace + "/" + opv.XOpenWhisk.ActionName
 						}
 						orderInfo = AssignListInfo(actionName, op, apiName, basePath, path, baseUrl+path)
-						whisk.Debug(whisk.DbgInfo, "Appening to orderInfoArr: %s %s\n", orderInfo.RelPath)
+						whisk.Debug(whisk.DbgInfo, "Appening to orderInfoArr: %s\n", orderInfo.RelPath)
 						orderInfoArr = append(orderInfoArr, orderInfo)
 					}
 				}
@@ -692,7 +692,7 @@ func genFilteredRow(resultApi *whisk.RetApi, apiPath string, apiVerb string, max
 						}
 						orderInfo = AssignRowInfo(actionName[0:min(len(actionName), maxActionNameSize)], op, apiName[0:min(len(apiName), maxApiNameSize)], basePath, path, baseUrl+path)
 						orderInfo.FmtString = fmtString
-						whisk.Debug(whisk.DbgInfo, "Appening to orderInfoArr: %s %s\n", orderInfo.RelPath)
+						whisk.Debug(whisk.DbgInfo, "Appening to orderInfoArr: %s\n", orderInfo.RelPath)
 						orderInfoArr = append(orderInfoArr, orderInfo)
 					}
 				}
@@ -987,7 +987,7 @@ func parseSwaggerApi(configfile string, namespace string) (*whisk.Api, error) {
 	}
 
 	if swaggerObj.BasePath == "" || swaggerObj.SwaggerName == "" || swaggerObj.Info == nil || swaggerObj.Paths == nil {
-		whisk.Debug(whisk.DbgError, "Swagger file is invalid.\n", configfile, err)
+		whisk.Debug(whisk.DbgError, "Swagger file is invalid.\n")
 		errMsg := wski18n.T("Swagger file is invalid (missing basePath, info, paths, or swagger fields)")
 		whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXIT_CODE_ERR_GENERAL,
 			whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
@@ -995,7 +995,7 @@ func parseSwaggerApi(configfile string, namespace string) (*whisk.Api, error) {
 	}
 
 	if _, ok := isValidBasepath(swaggerObj.BasePath); !ok {
-		whisk.Debug(whisk.DbgError, "Swagger file basePath is invalid.\n", configfile, err)
+		whisk.Debug(whisk.DbgError, "Swagger file basePath is invalid.\n")
 		errMsg := wski18n.T("Swagger file basePath must start with a leading slash (/)")
 		whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXIT_CODE_ERR_GENERAL,
 			whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -41,7 +41,7 @@ func SetupClientConfig(cmd *cobra.Command, args []string) error {
 
 	// Determine if the parent command will require the API host to be set
 	apiHostRequired := (cmd.Parent().Name() == "property" && cmd.Name() == "get" && (Flags.property.auth ||
-		Flags.property.cert || Flags.property.key || Flags.property.apihost || Flags.property.namespace ||
+		Flags.property.cert || Flags.property.key || Flags.property.apihost ||
 		Flags.property.apiversion || Flags.property.cliversion)) ||
 		(cmd.Parent().Name() == "property" && cmd.Name() == "set" && (len(Flags.property.apihostSet) > 0 ||
 			len(Flags.property.apiversionSet) > 0 || len(Flags.Global.Auth) > 0)) ||

--- a/commands/sdk.go
+++ b/commands/sdk.go
@@ -86,7 +86,7 @@ var sdkInstallCmd = &cobra.Command{
 			} else {
 				err = WskCmd.GenBashCompletionFile(BASH_AUTOCOMPLETE_FILENAME)
 				if err != nil {
-					whisk.Debug(whisk.DbgError, "GenBashCompletionFile('%s`) error: \n", BASH_AUTOCOMPLETE_FILENAME, err)
+					whisk.Debug(whisk.DbgError, "GenBashCompletionFile('%s`) error: %s\n", BASH_AUTOCOMPLETE_FILENAME, err)
 					errStr := wski18n.T("Unable to generate '{{.name}}': {{.err}}",
 						map[string]interface{}{"name": BASH_AUTOCOMPLETE_FILENAME, "err": err})
 					werr := whisk.MakeWskError(errors.New(errStr), whisk.EXIT_CODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)

--- a/commands/trigger.go
+++ b/commands/trigger.go
@@ -83,7 +83,7 @@ func createOrUpdate(Client *whisk.Client, fqn *QualifiedName, trigger *whisk.Tri
 	_, _, err := Client.Triggers.Insert(trigger, overwrite)
 
 	if err != nil {
-		whisk.Debug(whisk.DbgError, "Client.Triggers.Insert(%+v, %s) failed: %s\n", trigger, overwrite, err)
+		whisk.Debug(whisk.DbgError, "Client.Triggers.Insert(%+v, %t) failed: %s\n", trigger, overwrite, err)
 		var errStr string
 		if !overwrite {
 			errStr = wski18n.T("Unable to create trigger '{{.name}}': {{.err}}",

--- a/commands/util.go
+++ b/commands/util.go
@@ -75,7 +75,7 @@ func getParameters(params []string, keyValueFormat bool, annotation bool) interf
 
 	parameters, err = getJSONFromStrings(params, keyValueFormat)
 	if err != nil {
-		whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, %s) failed: %s\n", params, keyValueFormat, err)
+		whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, %t) failed: %s\n", params, keyValueFormat, err)
 		var errStr string
 
 		if !annotation {

--- a/tests/src/integration/command_test.go
+++ b/tests/src/integration/command_test.go
@@ -82,7 +82,7 @@ func TestShowAPIVersion(t *testing.T) {
 // Test case to verify the default namespace _.
 func TestDefaultNamespace(t *testing.T) {
 	common.CreateFile(tmpProp)
-	common.WriteFile(tmpProp, []string{"NAMESPACE="})
+	common.WriteFile(tmpProp, []string{"APIHOST=xyz"})
 
 	os.Setenv("WSK_CONFIG_FILE", tmpProp)
 	assert.Equal(t, os.Getenv("WSK_CONFIG_FILE"), tmpProp, "The environment variable WSK_CONFIG_FILE has not been set.")
@@ -101,7 +101,7 @@ func TestValidateDefaultProperties(t *testing.T) {
 	os.Setenv("WSK_CONFIG_FILE", tmpProp)
 	assert.Equal(t, os.Getenv("WSK_CONFIG_FILE"), tmpProp, "The environment variable WSK_CONFIG_FILE has not been set.")
 
-	stdout, err := wsk.RunCommand("property", "unset", "--auth", "--apihost", "--apiversion", "--namespace")
+	stdout, err := wsk.RunCommand("property", "unset", "--auth", "--apihost", "--apiversion")
 	assert.Equal(t, nil, err, "The command property unset failed to run.")
 	outputString := string(stdout)
 	assert.Contains(t, outputString, "ok: whisk auth unset",
@@ -110,8 +110,6 @@ func TestValidateDefaultProperties(t *testing.T) {
 		"The output of the command does not contain \"ok: whisk API host unset\".")
 	assert.Contains(t, outputString, "ok: whisk API version unset",
 		"The output of the command does not contain \"ok: whisk API version unset\".")
-	assert.Contains(t, outputString, "ok: whisk namespace unset",
-		"The output of the command does not contain \"ok: whisk namespace unset\".")
 
 	stdout, err = wsk.RunCommand("property", "get", "--auth")
 	assert.Equal(t, nil, err, "The command property get --auth failed to run.")
@@ -122,11 +120,6 @@ func TestValidateDefaultProperties(t *testing.T) {
 	assert.Equal(t, nil, err, "The command property get --apihost failed to run.")
 	assert.Equal(t, common.PropDisplayAPIHost, common.RemoveRedundentSpaces(string(stdout)),
 		"The output of the command does not equal to "+common.PropDisplayAPIHost)
-
-	stdout, err = wsk.RunCommand("property", "get", "--namespace")
-	assert.Equal(t, nil, err, "The command property get --namespace failed to run.")
-	assert.Equal(t, common.PropDisplayNamespace+" _", common.RemoveRedundentSpaces(string(stdout)),
-		"The output of the command does not equal to "+common.PropDisplayNamespace+" _")
 
 	common.DeleteFile(tmpProp)
 }

--- a/tests/src/integration/integration_test.go
+++ b/tests/src/integration/integration_test.go
@@ -22,7 +22,6 @@ package tests
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/apache/incubator-openwhisk-cli/tests/src/integration/common"
@@ -331,7 +330,7 @@ func initInvalidArgs() {
 var wsk *common.Wsk = common.NewWsk()
 var tmpProp = common.GetRepoPath() + "/wskprops.tmp"
 
-// Test case to set apihost, auth, and namespace.
+// Test case to set apihost and auth.
 func TestSetAPIHostAuthNamespace(t *testing.T) {
 	common.CreateFile(tmpProp)
 	common.WriteFile(tmpProp, []string{})
@@ -339,21 +338,15 @@ func TestSetAPIHostAuthNamespace(t *testing.T) {
 	os.Setenv("WSK_CONFIG_FILE", tmpProp)
 	assert.Equal(t, os.Getenv("WSK_CONFIG_FILE"), tmpProp, "The environment variable WSK_CONFIG_FILE has not been set.")
 
-	namespace, _ := wsk.ListNamespaces()
-	namespaces := strings.Split(strings.TrimSpace(string(namespace)), "\n")
-	expectedNamespace := string(namespaces[len(namespaces)-1])
 	fmt.Println(wsk.Wskprops.APIHost)
 	if wsk.Wskprops.APIHost != "" && wsk.Wskprops.AuthKey != "" {
-		stdout, err := wsk.RunCommand("property", "set", "--apihost", wsk.Wskprops.APIHost,
-			"--auth", wsk.Wskprops.AuthKey, "--namespace", expectedNamespace)
+		stdout, err := wsk.RunCommand("property", "set", "--apihost", wsk.Wskprops.APIHost, "--auth", wsk.Wskprops.AuthKey)
 		ouputString := string(stdout)
-		assert.Equal(t, nil, err, "The command property set --apihost --auth --namespace failed to run.")
+		assert.Equal(t, nil, err, "The command property set --apihost --auth failed to run.")
 		assert.Contains(t, ouputString, "ok: whisk auth set. Run 'wsk property get --auth' to see the new value.",
-			"The output of the command property set --apihost --auth --namespace does not contain \"whisk auth set\".")
+			"The output of the command property set --apihost --auth does not contain \"whisk auth set\".")
 		assert.Contains(t, ouputString, "ok: whisk API host set to "+wsk.Wskprops.APIHost,
-			"The output of the command property set --apihost --auth --namespace does not contain \"whisk API host set\".")
-		assert.Contains(t, ouputString, "ok: whisk namespace set to "+expectedNamespace,
-			"The output of the command property set --apihost --auth --namespace does not contain \"whisk namespace set\".")
+			"The output of the command property set --apihost --auth does not contain \"whisk API host set\".")
 	}
 	common.DeleteFile(tmpProp)
 }

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -285,10 +285,6 @@
     "translation": "Namespace '{{.name}}' is not in the list of entitled namespaces"
   },
   {
-    "id": "{{.ok}} whisk namespace set to {{.name}}\n",
-    "translation": "{{.ok}} whisk namespace set to {{.name}}\n"
-  },
-  {
     "id": "Unable to set the property value(s): {{.err}}",
     "translation": "Unable to set the property value(s): {{.err}}"
   },
@@ -311,10 +307,6 @@
   {
     "id": "{{.ok}} whisk auth unset.\n",
     "translation": "{{.ok}} whisk auth unset.\n"
-  },
-  {
-    "id": "{{.ok}} whisk namespace unset",
-    "translation": "{{.ok}} whisk namespace unset"
   },
   {
     "id": "{{.ok}} whisk API host unset.\n",


### PR DESCRIPTION
The setting of a namespace in wskprops can lead to surprising failures when it does not match the auth key. This value used to be there when namespaces and keys were not 1-1 but that hasn't been the case for a long time.

This patch remove --namespace from property set/unset but preserves --namespace in property get.

Partially fixes #137. Will open a subsequent PR to re-purpose `wsk namespace get`.