### PR TITLE
Pin Node.js version in tests

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -620,7 +620,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
         val webEnabled = flag.toLowerCase == "true" || flag.toLowerCase == "yes"
         val rawEnabled = flag.toLowerCase == "raw"
 
-        wsk.action.create(name, file, web = Some(flag), update = true, kind = "nodejs:10")
+        wsk.action.create(name, file, web = Some(flag), update = true, kind = Some("nodejs:10"))
 
         val action = wsk.action.get(name)
 
@@ -673,17 +673,23 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       overwrittenValue)
 
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, file, annotations = createAnnots, kind = "nodejs:10")
+      action.create(name, file, annotations = createAnnots, kind = Some("nodejs:10"))
     }
 
-    wsk.action.create(name, file, web = Some("true"), update = true, kind = "nodejs:10")
+    wsk.action.create(name, file, web = Some("true"), update = true, kind = Some("nodejs:10"))
 
     val existingAnnots = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
     assert(existingAnnots.startsWith(s"ok: got action $name, displaying field annotations\n"))
     removeCLIHeader(existingAnnots).parseJson.convertTo[Set[JsObject]] shouldBe createAnnotations.toJsArray
       .convertTo[Set[JsObject]]
 
-    wsk.action.create(name, file, web = Some("true"), update = true, annotations = updateAnnots, kind = "nodejs:10")
+    wsk.action.create(
+      name,
+      file,
+      web = Some("true"),
+      update = true,
+      annotations = updateAnnots,
+      kind = Some("nodejs:10"))
 
     val updatedAnnots =
       wsk.action.get(name, fieldFilter = Some("annotations")).stdout
@@ -698,7 +704,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       val file = Some(TestUtils.getTestActionFilename("echo.js"))
 
       assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, web = Some("true"), update = true, kind = "nodejs:10")
+        action.create(name, file, web = Some("true"), update = true, kind = Some("nodejs:10"))
       }
 
       val baseAnnotations =
@@ -776,7 +782,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
 
       // -web true --web-secure true -> annotation "require-whisk-auth" value is an int
       assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, web = Some("true"), websecure = Some("true"), kind = "nodejs:10")
+        action.create(name, file, web = Some("true"), websecure = Some("true"), kind = Some("nodejs:10"))
       }
       var stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
       var secretJsVar = removeCLIHeader(stdout).parseJson
@@ -793,7 +799,13 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       secretIsInt shouldBe true
 
       // -web true --web-secure string -> annotation "require-whisk-auth" with a value of string
-      wsk.action.create(name, file, web = Some("true"), websecure = Some(s"$secretStr"), update = true, kind = "nodejs:10")
+      wsk.action.create(
+        name,
+        file,
+        web = Some("true"),
+        websecure = Some(s"$secretStr"),
+        update = true,
+        kind = Some("nodejs:10"))
       stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
       val actualAnnotations =
         removeCLIHeader(stdout).parseJson.convertTo[JsArray].elements
@@ -804,7 +816,13 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       actualAnnotations.contains(JsObject("key" -> JsString("require-whisk-auth"), "value" -> JsString(s"$secretStr"))) shouldBe true
 
       // Updating web action multiple times with --web-secure true should not change the "require-whisk-auth" numeric value
-      wsk.action.create(name, file, web = Some("true"), websecure = Some("true"), update = true, kind = "nodejs:10")
+      wsk.action.create(
+        name,
+        file,
+        web = Some("true"),
+        websecure = Some("true"),
+        update = true,
+        kind = Some("nodejs:10"))
       stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
       val secretNumJsVar = removeCLIHeader(stdout).parseJson
         .convertTo[JsArray]
@@ -812,7 +830,13 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
         .find({
           _.convertTo[JsObject].getFields("key").head == JsString("require-whisk-auth")
         })
-      wsk.action.create(name, file, web = Some("true"), websecure = Some("true"), update = true, kind = "nodejs:10")
+      wsk.action.create(
+        name,
+        file,
+        web = Some("true"),
+        websecure = Some("true"),
+        update = true,
+        kind = Some("nodejs:10"))
       removeCLIHeader(stdout).parseJson
         .convertTo[JsArray]
         .elements
@@ -861,10 +885,10 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
     val secretStr = "my-secret"
 
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, file, web = Some("true"), annotations = createAnnots, kind = "nodejs:10")
+      action.create(name, file, web = Some("true"), annotations = createAnnots, kind = Some("nodejs:10"))
     }
 
-    wsk.action.create(name, file, websecure = Some(secretStr), update = true, kind = "nodejs:10")
+    wsk.action.create(name, file, websecure = Some(secretStr), update = true, kind = Some("nodejs:10"))
     var stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
     var existingAnnotations =
       removeCLIHeader(stdout).parseJson.convertTo[JsArray].elements
@@ -876,7 +900,13 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
     existingAnnotations.contains(JsObject("key" -> JsString(createKey), "value" -> createValue)) shouldBe true
     existingAnnotations.contains(JsObject("key" -> JsString(origKey), "value" -> origValue)) shouldBe true
 
-    wsk.action.create(name, file, websecure = Some(secretStr), update = true, annotations = updateAnnots, kind = "nodejs:10")
+    wsk.action.create(
+      name,
+      file,
+      websecure = Some(secretStr),
+      update = true,
+      annotations = updateAnnots,
+      kind = Some("nodejs:10"))
     stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
     var updatedAnnotations =
       removeCLIHeader(stdout).parseJson.convertTo[JsArray].elements
@@ -1207,7 +1237,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
 
     (wp, assetHelper) =>
       assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, defaultAction, parameters = paramInput, kind = "nodejs:10")
+        action.create(name, defaultAction, parameters = paramInput, kind = Some("nodejs:10"))
       }
 
       wsk.action.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -620,14 +620,14 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
         val webEnabled = flag.toLowerCase == "true" || flag.toLowerCase == "yes"
         val rawEnabled = flag.toLowerCase == "raw"
 
-        wsk.action.create(name, file, web = Some(flag), update = true)
+        wsk.action.create(name, file, web = Some(flag), update = true, kind = "nodejs:10")
 
         val action = wsk.action.get(name)
 
         val baseAnnotations = Parameters("web-export", JsBoolean(webEnabled || rawEnabled)) ++
           Parameters("raw-http", JsBoolean(rawEnabled)) ++
           Parameters("final", JsBoolean(webEnabled || rawEnabled)) ++
-          Parameters("exec", "nodejs:6")
+          Parameters("exec", "nodejs:10")
         val testAnnotations = if (requireAPIKeyAnnotation) {
           baseAnnotations ++ Parameters(WhiskAction.provideApiKeyAnnotationName, JsFalse)
         } else baseAnnotations
@@ -657,7 +657,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       Parameters("web-export", JsTrue) ++
         Parameters("raw-http", JsFalse) ++
         Parameters("final", JsTrue) ++
-        Parameters("exec", "nodejs:6")
+        Parameters("exec", "nodejs:10")
     val createAnnotations = if (requireAPIKeyAnnotation) {
       baseAnnotations ++
         Parameters(WhiskAction.provideApiKeyAnnotationName, JsFalse) ++
@@ -673,17 +673,17 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       overwrittenValue)
 
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, file, annotations = createAnnots)
+      action.create(name, file, annotations = createAnnots, kind = "nodejs:10")
     }
 
-    wsk.action.create(name, file, web = Some("true"), update = true)
+    wsk.action.create(name, file, web = Some("true"), update = true, kind = "nodejs:10")
 
     val existingAnnots = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
     assert(existingAnnots.startsWith(s"ok: got action $name, displaying field annotations\n"))
     removeCLIHeader(existingAnnots).parseJson.convertTo[Set[JsObject]] shouldBe createAnnotations.toJsArray
       .convertTo[Set[JsObject]]
 
-    wsk.action.create(name, file, web = Some("true"), update = true, annotations = updateAnnots)
+    wsk.action.create(name, file, web = Some("true"), update = true, annotations = updateAnnots, kind = "nodejs:10")
 
     val updatedAnnots =
       wsk.action.get(name, fieldFilter = Some("annotations")).stdout
@@ -698,14 +698,14 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       val file = Some(TestUtils.getTestActionFilename("echo.js"))
 
       assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, web = Some("true"), update = true)
+        action.create(name, file, web = Some("true"), update = true, kind = "nodejs:10")
       }
 
       val baseAnnotations =
         Parameters("web-export", JsTrue) ++
           Parameters("raw-http", JsFalse) ++
           Parameters("final", JsTrue) ++
-          Parameters("exec", "nodejs:6")
+          Parameters("exec", "nodejs:10")
 
       val testAnnotations = if (requireAPIKeyAnnotation) {
         baseAnnotations ++
@@ -776,7 +776,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
 
       // -web true --web-secure true -> annotation "require-whisk-auth" value is an int
       assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, web = Some("true"), websecure = Some("true"))
+        action.create(name, file, web = Some("true"), websecure = Some("true"), kind = "nodejs:10")
       }
       var stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
       var secretJsVar = removeCLIHeader(stdout).parseJson
@@ -793,18 +793,18 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
       secretIsInt shouldBe true
 
       // -web true --web-secure string -> annotation "require-whisk-auth" with a value of string
-      wsk.action.create(name, file, web = Some("true"), websecure = Some(s"$secretStr"), update = true)
+      wsk.action.create(name, file, web = Some("true"), websecure = Some(s"$secretStr"), update = true, kind = "nodejs:10")
       stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
       val actualAnnotations =
         removeCLIHeader(stdout).parseJson.convertTo[JsArray].elements
-      actualAnnotations.contains(JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6"))) shouldBe true
+      actualAnnotations.contains(JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:10"))) shouldBe true
       actualAnnotations.contains(JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(true))) shouldBe true
       actualAnnotations.contains(JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(false))) shouldBe true
       actualAnnotations.contains(JsObject("key" -> JsString("final"), "value" -> JsBoolean(true))) shouldBe true
       actualAnnotations.contains(JsObject("key" -> JsString("require-whisk-auth"), "value" -> JsString(s"$secretStr"))) shouldBe true
 
       // Updating web action multiple times with --web-secure true should not change the "require-whisk-auth" numeric value
-      wsk.action.create(name, file, web = Some("true"), websecure = Some("true"), update = true)
+      wsk.action.create(name, file, web = Some("true"), websecure = Some("true"), update = true, kind = "nodejs:10")
       stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
       val secretNumJsVar = removeCLIHeader(stdout).parseJson
         .convertTo[JsArray]
@@ -812,7 +812,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
         .find({
           _.convertTo[JsObject].getFields("key").head == JsString("require-whisk-auth")
         })
-      wsk.action.create(name, file, web = Some("true"), websecure = Some("true"), update = true)
+      wsk.action.create(name, file, web = Some("true"), websecure = Some("true"), update = true, kind = "nodejs:10")
       removeCLIHeader(stdout).parseJson
         .convertTo[JsArray]
         .elements
@@ -861,14 +861,14 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
     val secretStr = "my-secret"
 
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, file, web = Some("true"), annotations = createAnnots)
+      action.create(name, file, web = Some("true"), annotations = createAnnots, kind = "nodejs:10")
     }
 
-    wsk.action.create(name, file, websecure = Some(secretStr), update = true)
+    wsk.action.create(name, file, websecure = Some(secretStr), update = true, kind = "nodejs:10")
     var stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
     var existingAnnotations =
       removeCLIHeader(stdout).parseJson.convertTo[JsArray].elements
-    existingAnnotations.contains(JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6"))) shouldBe true
+    existingAnnotations.contains(JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:10"))) shouldBe true
     existingAnnotations.contains(JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(true))) shouldBe true
     existingAnnotations.contains(JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(false))) shouldBe true
     existingAnnotations.contains(JsObject("key" -> JsString("final"), "value" -> JsBoolean(true))) shouldBe true
@@ -876,11 +876,11 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
     existingAnnotations.contains(JsObject("key" -> JsString(createKey), "value" -> createValue)) shouldBe true
     existingAnnotations.contains(JsObject("key" -> JsString(origKey), "value" -> origValue)) shouldBe true
 
-    wsk.action.create(name, file, websecure = Some(secretStr), update = true, annotations = updateAnnots)
+    wsk.action.create(name, file, websecure = Some(secretStr), update = true, annotations = updateAnnots, kind = "nodejs:10")
     stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
     var updatedAnnotations =
       removeCLIHeader(stdout).parseJson.convertTo[JsArray].elements
-    updatedAnnotations.contains(JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6"))) shouldBe true
+    updatedAnnotations.contains(JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:10"))) shouldBe true
     updatedAnnotations.contains(JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(true))) shouldBe true
     updatedAnnotations.contains(JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(false))) shouldBe true
     updatedAnnotations.contains(JsObject("key" -> JsString("final"), "value" -> JsBoolean(true))) shouldBe true
@@ -1192,10 +1192,10 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
     val requireAPIKeyAnnotation = WhiskProperties.getBooleanProperty("whisk.feature.requireApiKeyAnnotation", true)
     val expectedParam = JsObject("payload" -> JsString("test"))
     val ns = wsk.namespace.whois()
-    val expectedExec = JsObject("kind" -> "nodejs:6".toJson, "binary" -> JsFalse)
+    val expectedExec = JsObject("kind" -> "nodejs:10".toJson, "binary" -> JsFalse)
     val expectedParams = Parameters("payload", "test")
     val baseAnnotations =
-      Parameters("exec", "nodejs:6")
+      Parameters("exec", "nodejs:10")
     val expectedAnnots = if (requireAPIKeyAnnotation) {
       baseAnnotations ++
         Parameters(WhiskAction.provideApiKeyAnnotationName, JsFalse)
@@ -1207,7 +1207,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
 
     (wp, assetHelper) =>
       assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, defaultAction, parameters = paramInput)
+        action.create(name, defaultAction, parameters = paramInput, kind = "nodejs:10")
       }
 
       wsk.action.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")


### PR DESCRIPTION
Since Node.js 10 is now the default for OpenWhisk these tests expecting Node.js 6 will fail.